### PR TITLE
Backpack/Bs

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -332,7 +332,7 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,20,10
+    - 0,0,9,6 # Forge-Change
 
 - type: entity
   parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpackClown

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -250,7 +250,7 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,19,9 # Mono Revert
+    - 0,0,16,9 # Forge-Change # Mono Revert
   - type: ClothingSpeedModifier
     sprintModifier: 1 # makes its stats identical to other variants of bag of holding
   - type: HeldSpeedModifier

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -186,7 +186,7 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,19,9 # Goob->Mono
+    - 0,0,11,8  # Forge-Change # Goob->Mono 
   - type: Clothing # Frontier
     sprite: _NF/Clothing/Back/Satchels/holding.rsi # Frontier
     clothingVisuals: # Frontier


### PR DESCRIPTION
Бездонные сумки

## PR.
Изменил вместимость бездомных сумок
бездонный рюкзак: было 0,0,20,10 (Слотов 200). Стало 0,0,9,6 (Слотов 54).
бездонный мессенджер: было 0,0,20,10 (Слотов 200). Стало 0,0,9,6 (Слотов 54).
бездонная сумка: было 0,0,19,9 (Слотов 171). Стало: 0,0,11,8 (Слотов 88).
бездонный вещмешок: Было 0,0,19,9 (Слотов 171). Стало: 0,0,16,9 (Слотов 144).
