### PR TITLE
Access_to_USSP_For_VendingMachineUSSP

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/vending_machines.yml
@@ -60,7 +60,7 @@
     - state: panel
       map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
   - type: AccessReader
-    access: [["Mercenary"], ["Security"]]
+    requiredCompany: USSP # Forge-change
 
 - type: entity
   parent: [BaseStructureDisableToolUse, VendingMachineSyndieContraband]


### PR DESCRIPTION
VendingMachineUSSP теперь доступен только для СССП. 
Игроки без ID-карты Компании СССП. не смогут покупать вещи.
:)