### PR TITLE
Fix: gun recoil unbuckles riders from vehicles

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -76,6 +76,7 @@ public abstract partial class SharedGunSystem : EntitySystem
 
     protected EntityQuery<PhysicsComponent> _physQuery; // Mono
     protected EntityQuery<ProjectileComponent> _projQuery; // Mono
+    protected EntityQuery<BuckleComponent> _buckleQuery; // Mono
     private EntityQuery<AutoShootGunComponent> _autoShootGunQuery; // Mono
 
     private const float InteractNextFire = 0.3f;
@@ -118,6 +119,7 @@ public abstract partial class SharedGunSystem : EntitySystem
 
         _physQuery = GetEntityQuery<PhysicsComponent>(); // Mono
         _projQuery = GetEntityQuery<ProjectileComponent>(); // Mono
+        _buckleQuery = GetEntityQuery<BuckleComponent>(); // Mono
         _autoShootGunQuery = GetEntityQuery<AutoShootGunComponent>();
     }
 
@@ -727,6 +729,12 @@ public abstract partial class SharedGunSystem : EntitySystem
             impulseCoord = TransformSystem.WithEntityId(impulseCoord, selfXform.ParentUid);
 
         var toEnt = impulseCoord.EntityId;
+
+        // Mono - if the shooter is buckled (e.g. riding a vehicle), apply the recoil to whatever
+        // they're buckled to instead, so the kick doesn't shove them out of their seat.
+        if (_buckleQuery.TryComp(toEnt, out var buckle) && buckle.BuckledTo is { } buckledTo)
+            toEnt = buckledTo;
+
         if (!_physQuery.TryComp(toEnt, out var toBody))
             return;
 


### PR DESCRIPTION
## Summary
- Firing a weapon while buckled to something with a `StrapComponent` (e.g. riding a hoverbike) applied the recoil impulse directly to the shooter's body.
- This could push the rider's position past the strap's `unbuckleDistanceSquared`, causing them to be automatically unbuckled and thrown off the vehicle, especially with high-recoil weapons.
- Recoil is now redirected to whatever the shooter is currently buckled to (`BuckleComponent.BuckledTo`), so the kick is absorbed by the vehicle instead of ejecting the rider.

## Changes
- `Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs`: added a `BuckleComponent` query and, in `CauseImpulse`, redirect the recoil target entity to `BuckledTo` when the shooter is buckled.

## Test plan
- [x] Solution builds (`Content.Shared`, `Content.Server`, `Content.Client`) with no new errors/warnings.
- [x] Started a local dedicated server + client with the change; connected and entered a round with no errors related to `GunComponent`/`BuckleComponent`.
- [ ] In-game: ride a hoverbike, fire a weapon with significant recoil, confirm you stay buckled.