### PR TITLE
Копьё: урон и встревание от скорости движения (Momentum Melee)

### DIFF
--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -422,7 +422,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         }
     }
 
-    private void EmbedAttach(EntityUid uid, EntityUid target, EntityUid? user, EmbeddableProjectileComponent component)
+    public void EmbedAttach(EntityUid uid, EntityUid target, EntityUid? user, EmbeddableProjectileComponent component)
     {
         // Forge-Change-start: prediction can embed twice (Drake hardsuit grappling hook).
         if (component.EmbeddedIntoUid != null)

--- a/Content.Shared/Weapons/Melee/MomentumMeleeComponent.cs
+++ b/Content.Shared/Weapons/Melee/MomentumMeleeComponent.cs
@@ -1,0 +1,72 @@
+using Content.Shared.Damage;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.Weapons.Melee;
+
+/// <summary>
+/// While this item is held in a hand, moving into a mob (in the direction of movement)
+/// deals damage scaled by the holder's movement speed, Minecraft-spear style.
+/// The held item has no active physics body, so the holder's velocity is used and
+/// targets are found with a proactive lookup in a forward cone each tick.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class MomentumMeleeComponent : Component
+{
+    /// <summary>
+    /// Base damage payload, scaled by the speed factor. Applied per hit.
+    /// </summary>
+    [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
+    public DamageSpecifier Damage = default!;
+
+    /// <summary>
+    /// Holder must move at least this fast (m/s) for the effect to trigger.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float MinimumSpeed = 4.5f;
+
+    /// <summary>
+    /// Multiplier in the damage formula: Damage * SpeedDamageFactor * speed / MinimumSpeed.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float SpeedDamageFactor = 0.5f;
+
+    /// <summary>
+    /// Contact range (metres) from the holder within which mobs are hit.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float Range = 0.6f;
+
+    /// <summary>
+    /// Full width (degrees) of the forward cone in the direction of movement.
+    /// Targets outside this cone are ignored.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float ArcDegrees = 90f;
+
+    /// <summary>
+    /// Per-target cooldown (seconds) between hits.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float DamageCooldown = 1f;
+
+    /// <summary>
+    /// Sound played on a successful hit.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public SoundSpecifier? SoundHit = new SoundCollectionSpecifier("MetalThud");
+
+    /// <summary>
+    /// If true and the item has an <see cref="Content.Shared.Projectiles.EmbeddableProjectileComponent"/>,
+    /// a successful hit drops the item from the hand and embeds it into the target.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool EmbedOnHit = false;
+
+    /// <summary>
+    /// Per-target time of last hit, used for the cooldown. Not serialized.
+    /// </summary>
+    [ViewVariables]
+    public Dictionary<EntityUid, TimeSpan> LastHit = new();
+}

--- a/Content.Shared/Weapons/Melee/MomentumMeleeSystem.cs
+++ b/Content.Shared/Weapons/Melee/MomentumMeleeSystem.cs
@@ -1,0 +1,158 @@
+using System.Numerics;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Effects;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Projectiles;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.Weapons.Melee;
+
+/// <summary>
+/// Handles <see cref="MomentumMeleeComponent"/>: a held item that damages mobs it is
+/// carried into, scaled by the holder's movement speed (Minecraft-spear style).
+/// </summary>
+public sealed class MomentumMeleeSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedProjectileSystem _projectile = default!;
+
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+
+    // Reused per-tick scratch buffers to avoid allocations.
+    private readonly HashSet<Entity<MobStateComponent>> _targets = new();
+    private readonly List<EntityUid> _staleCooldowns = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var now = _timing.CurTime;
+        var query = AllEntityQuery<MomentumMeleeComponent, TransformComponent>();
+
+        while (query.MoveNext(out var uid, out var comp, out var xform))
+        {
+            // The item must be held in an actual hand (not a pocket/bag, which also
+            // parent to the same mob). A held item is parented to the holder.
+            var holder = xform.ParentUid;
+
+            if (!holder.IsValid() || !_hands.IsHolding(holder, uid))
+            {
+                if (comp.LastHit.Count > 0)
+                    comp.LastHit.Clear();
+                continue;
+            }
+
+            // Cheap velocity gate before doing any lookups.
+            if (!_physicsQuery.TryGetComponent(holder, out var physics))
+                continue;
+
+            // Use map-frame velocity so it works while riding a vehicle / standing on a
+            // moving grid: the holder is parented to the vehicle and its own LinearVelocity
+            // is ~0, but the real speed is that of the parent chain.
+            var velocity = _physics.GetMapLinearVelocity(holder, physics);
+            var speed = velocity.Length();
+
+            if (speed < comp.MinimumSpeed)
+                continue;
+
+            var moveDir = velocity / speed; // normalized
+            var holderPos = _transform.GetWorldPosition(holder);
+            var cosHalfArc = (float) Math.Cos(Angle.FromDegrees(comp.ArcDegrees).Theta / 2);
+
+            _targets.Clear();
+            _lookup.GetEntitiesInRange(_transform.GetMapCoordinates(holder), comp.Range, _targets);
+
+            foreach (var target in _targets)
+            {
+                if (target.Owner == holder || target.Owner == uid)
+                    continue;
+
+                if (!_mobState.IsAlive(target.Owner, target.Comp))
+                    continue;
+
+                // Forward-cone filter: target must lie in the direction of movement.
+                var toTarget = _transform.GetWorldPosition(target.Owner) - holderPos;
+
+                if (toTarget.LengthSquared() > 0f)
+                {
+                    if (Vector2.Dot(moveDir, Vector2.Normalize(toTarget)) < cosHalfArc)
+                        continue;
+                }
+
+                // Per-target cooldown.
+                if (comp.LastHit.TryGetValue(target.Owner, out var last)
+                    && (now - last).TotalSeconds < comp.DamageCooldown)
+                    continue;
+
+                comp.LastHit[target.Owner] = now;
+
+                var damageScale = comp.SpeedDamageFactor * speed / comp.MinimumSpeed;
+                _damageable.TryChangeDamage(target.Owner, comp.Damage * damageScale, origin: holder);
+
+                if (comp.SoundHit != null && _timing.IsFirstTimePredicted)
+                    _audio.PlayPvs(comp.SoundHit, target.Owner, AudioParams.Default.WithVariation(0.125f));
+
+                _color.RaiseEffect(Color.Red, new List<EntityUid> { target.Owner }, Filter.Pvs(target.Owner, entityManager: EntityManager));
+
+                // Optionally embed the weapon into the target, dropping it from the hand.
+                if (comp.EmbedOnHit
+                    && TryComp<EmbeddableProjectileComponent>(uid, out var embeddable)
+                    && embeddable.EmbeddedIntoUid == null)
+                {
+                    _hands.TryDrop(holder, uid, checkActionBlocker: false, doDropInteraction: false);
+                    _projectile.EmbedAttach(uid, target.Owner, holder, embeddable);
+                    break; // weapon left the hand; stop scanning further targets
+                }
+            }
+
+            CleanupCooldowns(comp, now);
+        }
+    }
+
+    /// <summary>
+    /// Drops stale cooldown entries so the dictionary doesn't grow unbounded.
+    /// </summary>
+    private void CleanupCooldowns(MomentumMeleeComponent comp, TimeSpan now)
+    {
+        if (comp.LastHit.Count == 0)
+            return;
+
+        var cooldown = comp.DamageCooldown;
+        _staleCooldowns.Clear();
+
+        foreach (var (target, last) in comp.LastHit)
+        {
+            if ((now - last).TotalSeconds >= cooldown)
+                _staleCooldowns.Add(target);
+        }
+
+        foreach (var target in _staleCooldowns)
+        {
+            comp.LastHit.Remove(target);
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -47,6 +47,15 @@
     damage:
       types:
         Piercing: 25
+  - type: MomentumMelee
+    damage:
+      types:
+        Piercing: 12
+    minimumSpeed: 4.5
+    speedDamageFactor: 1.0
+    embedOnHit: true
+    soundHit:
+      path: /Audio/Weapons/bladeslice.ogg
   - type: Item
     size: Ginormous
   - type: Clothing


### PR DESCRIPTION
## Описание

Добавляет копью (и любому оружию через новый переиспользуемый компонент) механику урона от скорости в духе Minecraft: пока предмет держат **в руке** и владелец движется быстрее порога, набегание/наезд остриём вперёд наносит цели урон, пропорциональный скорости. На достаточной скорости копьё **втыкается** в цель.

## Как это работает

Предмет в руке лежит в контейнере руки — у него нет активного физического тела, поэтому событий коллизии он не генерирует. Кроме того, обычные мобы проходят друг сквозь друга (их жёсткие фикстуры не пересекаются, расталкивание — отдельная «мягкая» система). Поэтому механика реализована **проактивной проверкой** на стороне владельца:

- Каждый тик для предметов с `MomentumMelee`, которые реально держат в руке (`IsHolding`), берём скорость владельца в мировых координатах через `GetMapLinearVelocity` — это учитывает движение по цепочке родителей, так что механика работает и когда игрок **едет на транспорте** (ховербайк, квадроцикл), будучи запаренченным к нему.
- Если скорость ≥ `minimumSpeed`, ищем живых мобов в радиусе `range` в **конусе по направлению движения** (`ArcDegrees`) и наносим урон по формуле `damage * speedDamageFactor * speed / minimumSpeed` (та же логика, что в существующем `DamageOnHighSpeedImpactSystem`) — с покадровым эффектом (красная вспышка + звук) и кулдауном на цель.
- При включённом `embedOnHit` и наличии `EmbeddableProjectile` успешный удар роняет предмет из руки и втыкает его в цель через существующий `EmbedAttach` (вытаскивается как обычное воткнутое копьё).

Формула, эффекты и вытаскивание копья переиспользуют уже имеющиеся системы (`DamageableSystem`, `SharedColorFlashEffectSystem`, `SharedProjectileSystem`), новой «магии» не вводится.

## Изменения

- Новый компонент `MomentumMeleeComponent` (`Content.Shared/Weapons/Melee/`) — переиспользуемый, настраивается в YAML.
- Новая система `MomentumMeleeSystem` (shared).
- `EmbedAttach` в `SharedProjectileSystem` сделан `public`, чтобы встревание можно было вызвать из других систем.
- Компонент `MomentumMelee` добавлен на базовый `Spear` (варианты наследуют).

## Медиа

<!-- ⬇️ ПЕРЕТАЩИ СЮДА ФАЙЛ 2026-07-08 20-08-36.mp4 (GitHub сам загрузит и вставит видео) ⬇️ -->

## Проверка

- Стоя рядом с мобом — урона нет; на бегу/на транспорте остриём вперёд — Piercing-урон + вспышка + звук, растёт со скоростью.
- Мобы сбоку/сзади не задеваются (конус спереди).
- Копьё не в руке (в сумке/на спине) — механика молчит.
- Обычный ближний удар и бросок копья не изменились.

:cl: Grom1halo
- add: Копьё теперь наносит урон при столкновении на скорости (в руке) и втыкается в цель — как в Minecraft.
