### PR TITLE
Фиксы минорные

### DIFF
--- a/Content.Shared/_NF/Clothing/EntitySystems/NFMoonBootsSystem.cs
+++ b/Content.Shared/_NF/Clothing/EntitySystems/NFMoonBootsSystem.cs
@@ -13,6 +13,7 @@ namespace Content.Shared._NF.Clothing.EntitySystems;
 
 public sealed partial class SharedNFMoonBootsSystem : EntitySystem
 {
+    [Dependency] private SharedGravitySystem _gravity = default!; /// Change-Forge
     [Dependency] private AlertsSystem _alerts = default!;
     [Dependency] private ClothingSystem _clothing = default!;
     [Dependency] private InventorySystem _inventory = default!;
@@ -40,6 +41,7 @@ public sealed partial class SharedNFMoonBootsSystem : EntitySystem
             && uid == worn)
         {
             UpdateMoonbootEffects(container.Owner, ent, args.Activated);
+            _gravity.RefreshWeightless(container.Owner); /// Change-Forge
         }
 
         var prefix = args.Activated ? "on" : null;
@@ -50,11 +52,13 @@ public sealed partial class SharedNFMoonBootsSystem : EntitySystem
     private void OnGotUnequipped(Entity<NFMoonBootsComponent> ent, ref ClothingGotUnequippedEvent args)
     {
         UpdateMoonbootEffects(args.Wearer, ent, false);
+        _gravity.RefreshWeightless(args.Wearer); /// Change-Forge
     }
 
     private void OnGotEquipped(Entity<NFMoonBootsComponent> ent, ref ClothingGotEquippedEvent args)
     {
         UpdateMoonbootEffects(args.Wearer, ent, _toggle.IsActivated(ent.Owner));
+        _gravity.RefreshWeightless(args.Wearer); /// Change-Forge
     }
 
     public void UpdateMoonbootEffects(EntityUid user, Entity<NFMoonBootsComponent> ent, bool state)

--- a/Resources/Locale/ru-RU/_NF/chat/emotes.ftl
+++ b/Resources/Locale/ru-RU/_NF/chat/emotes.ftl
@@ -59,5 +59,4 @@ chat-emote-msg-vulpkanin-whines = скулит
 chat-emote-msg-vulpkanin-howls = воет
 chat-emote-msg-vulpkanin-awoo = воет
 
-chat-emote-name-hiss = Шипеть
 chat-emote-msg-hiss = шипит

--- a/Resources/Locale/ru-RU/recipes/recipes.ftl
+++ b/Resources/Locale/ru-RU/recipes/recipes.ftl
@@ -90,4 +90,4 @@ construction-recipe-suit-storage = { ent-SuitStorageBase }
 construction-recipe-suit-storage-desc = { ent-SuitStorageBase.desc }
 
 construction-recipe-suit-storage-wallmount = { ent-SuitStorageWallmount }
-construction-recipe-suit-storage-desc = { ent-SuitStorageWallmount.desc }
+construction-recipe-suit-storage-wallmount-desc = { ent-SuitStorageWallmount.desc }

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -34,7 +34,7 @@
   - type: Tag
     tags:
     - BoxCardboard
-    - Trash # Frontier
+    # - Trash # Frontier #Forge-Change-Del
 
 - type: entity
   name: mousetrap box

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -361,6 +361,17 @@
           prob: 0.1
         - id: ShardGlassPlasma
           prob: 0.1
+          # Forge-Change-Start
+          # Goblin
+        - id: FireExtinguisher
+          prob: 0.05
+        - id: TrashBag
+          prob: 0.2
+        - id: Beaker
+          prob: 0.05
+        - id: DrinkColaCanEmpty
+          prob: 0.15
+          # Forge-Change-End
 
 - type: entity
   id: CrateCandles

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/trash.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/trash.yml
@@ -27,6 +27,7 @@
       - id: FoodTinMRETrash # Frontier
       - id: MysteryFigureBoxTrash # Frontier
       - id: FoodPSBTrash # Frontier
+      - id: DrinkColaCanEmpty # Forge-Change
     - !type:GroupSelector
       weight: 5
       children:
@@ -35,6 +36,8 @@
       - id: TrashBananaPeel # Frontier
       - id: FoodCornTrash # Frontier
       - id: TrashNapkin # Frontier
+      - id: Beaker      # Forge-Change
+      - id: DrinkGlass  # Forge-Change
 
 - type: entity
   name: Trash Spawner

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -345,10 +345,12 @@
 - type: weightedRandomEntity
   id: RatKingLoot
   weights: # DeltaV: Rebalanced for Rodentia rummaging because we don't have Rat King
-    RandomSpawner100: 100 #garbage
-#    FoodCheeseSlice: 15 #food
-#    RandomSnacks: 10
-#    RandomFoodSingle: 5
+  # Forge-Change-Start
+    RandomSpawner100: 85 #garbage
+    FoodCheeseSlice: 5   #food
+    RandomSnacks: 5
+    RandomFoodSingle: 5
+  # Forge-Change-End
 
 - type: entity
   id: ActionRatKingRaiseArmy

--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -26,6 +26,7 @@
     tags:
     - Recyclable
     - GoblinPreciousTrash # Forge-Change
+    - Trash               # Forge-Change
 
 - type: entity
   parent: BaseStructure
@@ -125,6 +126,8 @@
   - type: Tag
     tags:
     - MachineBoard
+    - Trash
+    - Recyclable
   # Forge-Change-End
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -93,8 +93,8 @@
   - type: StaticPrice
     price: 30
   - type: DnaSubstanceTrace
-  - type: TrashOnSolutionEmpty # Frontier
-    solution: beaker # Frontier
+  # - type: TrashOnSolutionEmpty # Frontier # Forge-Change-Del
+  #   solution: beaker # Frontier           # Forge-Change-Del
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Objects/Tools/binoculars.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/binoculars.yml
@@ -14,7 +14,7 @@
     delay: 1.0
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
-    maxOffset: 5
+    maxOffset: 10
     pvsIncrease: 0.5
   - type: SpeedModifiedOnWield
     walkModifier: 0.95

--- a/Resources/Prototypes/Entities/Objects/Tools/binoculars.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/binoculars.yml
@@ -14,7 +14,7 @@
     delay: 1.0
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
-    maxOffset: 10
+    maxOffset: 10 # Forge-Change
     pvsIncrease: 0.5
   - type: SpeedModifiedOnWield
     walkModifier: 0.95

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -68,5 +68,5 @@
   #   materialComposition:
   #     Plastic: 50
   - type: DnaSubstanceTrace
-  - type: TrashOnSolutionEmpty # Frontier
-    solution: bucket # Frontier
+  # - type: TrashOnSolutionEmpty # Frontier # Forge-Change-Del
+  #   solution: bucket # Frontier           # Forge-Change-Del

--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -38,6 +38,7 @@
         sound:
           collection: MetalGlassBreak
       - !type:ExplodeBehavior
+  - type: GravityAffected # Forge-Change
 
 - type: entity
   parent: BaseVehicle

--- a/Resources/Prototypes/Entities/Structures/Machines/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/frame.yml
@@ -130,6 +130,7 @@
           whitelist:
             components:
             - MachineBoard
+    - type: GravityAffected # Forge-Change
 
 - type: entity
   id: MachineFrameDestroyed

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -633,6 +633,7 @@
       sprite: Structures/Storage/Crates/labels.rsi
       offset: "0.0,0.03125"
       map: ["enum.PaperLabelVisuals.Layer"]
+  - type: RatKingRummageable # Forge-Change
 
 - type: entity
   parent: CrateBaseSecure

--- a/Resources/Prototypes/_Forge/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/_Forge/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -62,6 +62,7 @@
     - type: Tag
       tags:
       - PortableGeneratorClunkerCircuitboard
+      - Trash
 
 - type: entity
   id: GoblinThrusterCircuitboard
@@ -89,6 +90,7 @@
     - type: Tag
       tags:
       - GoblinThrusterCircuitboard
+      - Trash
 
 - type: entity
   id: GoblinComputerShuttleCircuitboard
@@ -110,6 +112,9 @@
     - type: Construction
       graph: goblin_makeshift_circuit
       node: goblinComputerShuttleCircuitboard
+    - type: Tag
+      tags:
+      - Trash
 
 - type: entity
   parent: BaseItem
@@ -127,3 +132,6 @@
   - type: Construction
     graph: goblin_makeshift_circuit
     node: incompleteCircuitboard
+  - type: Tag
+    tags:
+    - Trash

--- a/Resources/Prototypes/_Forge/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/_Forge/Entities/Structures/Shuttles/thrusters.yml
@@ -18,6 +18,8 @@
         shader: unshaded
         visible: false
         offset: 0, 0.5
+    - type: Machine
+      board: GoblinThrusterCircuitboard
     - type: Construction
       graph: goblin_machinery
       node: goblinThruster

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/base_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/base_launcher.yml
@@ -72,6 +72,7 @@
   - type: Repairable
     qualities:
     - Applicating
+  - type: GravityAffected # Forge-Change
 
 - type: entity
   id: BallisticArtilleryUnanchorable
@@ -172,6 +173,7 @@
   - type: Repairable
     qualities:
     - Applicating
+  - type: GravityAffected # Forge-Change
 
 - type: entity
   id: BallisticArtilleryCartridge
@@ -284,6 +286,7 @@
   - type: Repairable
     qualities:
     - Applicating
+  - type: GravityAffected # Forge-Change
 
 - type: entity
   id: BallisticArtilleryMagazine
@@ -341,6 +344,7 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
+  - type: GravityAffected # Forge-Change
 
 - type: entity
   id: BallisticArtilleryTier2HP # Normal weapons, slightly stronger than plastitanium. This is the baseline durability for your average sized anchorable weapon.
@@ -361,6 +365,7 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
+  - type: GravityAffected # Forge-Change
 
 - type: entity
   id: BallisticArtilleryTier3HP # Medium weapons. Reinforced plastitanium level. Typical for medium-class weapons. In-between heavy artillery and standard anchorables.
@@ -387,6 +392,7 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
+  - type: GravityAffected # Forge-Change
 
 - type: entity
   id: BallisticArtilleryTier4HP # Capital Weapons. Cyrexas, main cannons. Anything really big.
@@ -413,6 +419,7 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
+  - type: GravityAffected # Forge-Change
 
 - type: entity
   id: BallisticArtilleryTier5HP # Supercapital class armament, station outpost weaponry and capital pre-fracture weaponry, around 4x Reinforced Plastitanium Health.
@@ -439,3 +446,4 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
+  - type: GravityAffected # Forge-Change

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/salvage.yml
@@ -58,4 +58,4 @@
 - type: entity
   id: NFCrateSalvageAssortedGoodiesTrashCart
   categories: [ HideSpawnMenu ]
-  parent: [ CrateTrashCart, NFCrateSalvageAssortedGoodies ]
+  parent: [ CrateTrashCartFilled ] # Forge-Change

--- a/Resources/Prototypes/_NF/Entities/Structures/Storage/trash_box.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Storage/trash_box.yml
@@ -115,4 +115,5 @@
       - Recyclable
       - Trash
     maxItemSize: Huge # so you can pick up scrap chunks
+  - type: RatKingRummageable
     # Forge-Change-End


### PR DESCRIPTION
## О PR
Исправляю  что наделал не так как и в целом багфиксы с мелкими фичами:
- Исправление 2 дублирование уже существующих айдишек в .ftl ru-translate,
- Неправильная плата у Тырчика - у него была плата обычного Двигателя(ThrusterCircuitboard) а не Гоблинского(GoblinThrusterCircuitboard)..
- Каркасам, Баллистическому Оружию и главное  всему транспорту по типу, Ховербайкам и Квадроциклам добавил   `- type: GravityAffected`.
_В связи добавление нового компонента `GravityAffected` теперь надо чтобы все предметы у которых может меняться гравитация надо добавлять его а у Каркасов, Ховербайков и баллистики их не было ибо оригинальные и не наследовались от базовых вещей с соответствующим компонентом, я добавил каждому самому высшему родителю этот компонент._
- Добавил обновление веса владельцу в логику луноходов при изменению их статуса.
- Увеличил максимальную дальность бинокля с 5 до 10.
- Исправлены мусорные контейнеры на обломках - они теперь содержат МУСОР который жизненно необходим для гоблинов а до этого содержали ценные материалы что не стыковалось с их внешним видом, так же им был отрегулирован лут и там теперь могут появится мусорные мешки, огнетушитель и пустые банки от колы с маленькой мензуркой,
- Исправлены Тэги Мусора большинства объектов которые их не должна содержать(Мензурки, Аварийные Наборы, Вёдра) и добавлены объектам которые мусором являются, но не имеют Тэга Мусор(В большинстве своём это Scrap и ScrapGlass), так же еще мусором теперь являются мусорные платы Гоблинов.,
- Теперь Мусорные Контейнеры и Мусорные Тележки имеют компонент RatKingRummageable и их могут обшаривать Гоблины и Рэткины для поиска мусора а так же в лут вернул снэки и кусочки сыра, но уменшил шанс его появление до 5 процентов. 

## Зачем \ Баланс
- Без GravityAffected объекты всегда будут с гравитацией, даже в космосе и от этого квадроциклы умеют колесить по вакууму, ховеры никогда не будут ускорятся в космосе а баллистика с каркасами всегда будут стоять неподъемно на одном месте в антигравитации..
- Луноходы устарели и им не добавили обновление статуса владельцу от чего они никогда не работали и были бесполезными, теперь работают исправно. 
- Бинокль занимает много место в рюкзаке и практически бесполезен для разведки ведь тебя тут же спалят сделав пару шагов в твою сторону. Проще говоря 5 клеток слишком мало делая его бесполезным а теперь с 10 клетками намного эффективен для разведки! Да и странно что биноколь хуже работает любой снайперской винтовки.  
- На обломках парадоксально ценных вещей больше чем мусора от чего абсурдно даже находить бриллианты в мусорном контейнере а гоблины вынуждены искать мусор на станциях чем в космосе. Огнетушители и мусорные мешки очень важная часть геймплея за гоблинов, они нужны им для создание движков и сбора мусора по этому их теперь можно найти в мусорных контейнерах что вполне соответствует действительности.
- Очень серьезное была ошибка давать вёдрам TrashOnSolution и аварийным наборам Тэг Trash ведь ведро после опустошение можно опять наполнить чем угодно и убрать в мусорный мешок вместе с жидкостью а аварийный набор заполнять инструментами и медипенами а потом убирать тоже в мусорный мешок, делая мешок лучшим местом для хранение после блюспейс мешков. Так же большая часть мусора на обломках нельзя было собирать в мусорные мешки что сбивает с толку тех кто собирает мусор на них.
- Гоблины и Рэткины могли шарить лишь унитазы и мусорные единицы которые были большой редкостью на кораблях и очень малом количестве учитывая кулдаун в 5 минут заниматься этим совершенно бесмысленно учитывая что вещи которые выпадали были бесполезным мусором, теперь любая мусорная тележка или контейнер можно шарить и их можно найти на любом обломке, там может быть еда а гоблины могут найти мензурки  и пустые банки как место хранение жидкостей и необходимых предметов для сборки Протолата а Раткины кусочек сыра для лечения. 

https://discordapp.com/channels/1222332535628103750/1525214954997940324/1525214954997940324

https://discordapp.com/channels/1222332535628103750/1525440912656826398/1525440912656826398

## Требования
- [ ] Я прочитал(а) релевантные гайдлайны/документацию для этого PR на [нашем devwiki](https://monolith-station.github.io/mono-docs/).
- [ ] Я добавил(а) медиа в этот PR, либо для него не требуется демонстрация в игре.
- [X] Подтверждаю, что PR либо не содержит AI-сгенерированного контента, либо этот контент соответствует нашим правилам.

**Changelog**
:cl: Gordod3
- fix: Ховербайки снова работают в космосе!
- fix: Баллистические орудиям вернули законы физики, теперь в космосе они летают как надо.
- fix: Луноходы снова работают.
- fix: Мусорные Тележки на обломках содержат мусор, вот чудо!
- tweak: Мусорные Тележки теперь можно "шарить" на наличие мусора!
- tweak: Теперь обшаривая Мусорные Единицы можно найти СЫР!
- tweak: Биноклю увеличили вдвое дальность обзора!