### PR TITLE
Хотфикс хрупкости больших шаттлов!

### DIFF
--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -123,7 +123,7 @@ namespace Content.Shared.Maps
         /// Effective mass of this tile for grid impacts.
         /// </summary>
         [DataField]
-        public float Mass = SharedShuttleSystem.TileDensityMultiplier; /// Forge-Change
+        public float Mass = 1000f; /// Forge-Change
 
         // <Mono>
         /// <summary>


### PR DESCRIPTION
## О PR
Значение массы было равно 0.5 вместо 1000 и от того крупные шаттлы были очень хрупкими и разрушительными!

## Медиа
До Фикса

https://github.com/user-attachments/assets/9b2e228b-42e9-46f9-ab84-087abba16391

После Фикса

https://github.com/user-attachments/assets/37e1a45e-ec0c-4d27-8a28-8267e3d8a74f


**Changelog**

:cl:
- fix: Большие Шаттлы больше не будут такими хрупкими
