### PR TITLE
Баннеры полноценно работают на астероидах и обломках!

### DIFF
--- a/Content.Server/Worldgen/Systems/GC/GCQueueSystem.cs
+++ b/Content.Server/Worldgen/Systems/GC/GCQueueSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Server.Worldgen.Components.GC;
 using Content.Server.Worldgen.Prototypes;
 using Content.Shared.CCVar;
+using Content.Server._Mono.GridClaimer; /// Forge-Change
 using JetBrains.Annotations;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
@@ -62,6 +63,10 @@ public sealed partial class GCQueueSystem : EntitySystem
                 var e = queue.Dequeue();
                 if (!Deleted(e))
                 {
+                    // don't delete it if claimed
+                    if (TryComp<ClaimableGridComponent>(e, out var claimable) && claimable.Claimed) /// Forge-Change
+                        continue;                                                                   /// Forge-Change
+
                     var ev = new TryCancelGC();
                     RaiseLocalEvent(e, ref ev);
 
@@ -78,6 +83,10 @@ public sealed partial class GCQueueSystem : EntitySystem
     /// <param name="e">Entity to GC.</param>
     public void TryGCEntity(EntityUid e)
     {
+        // don't delete it if claimed
+        if (TryComp<ClaimableGridComponent>(e, out var claimable) && claimable.Claimed) /// Forge-Change
+            return;                                                                     /// Forge-Change
+
         if (!TryComp<GCAbleObjectComponent>(e, out var comp))
         {
             QueueDel(e); // not our problem :)

--- a/Content.Server/_Mono/Cleanup/BaseCleanupSystem.cs
+++ b/Content.Server/_Mono/Cleanup/BaseCleanupSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._Mono.CCVar;
 using Robust.Shared.Configuration;
+using Content.Server._Mono.GridClaimer; /// Forge-Change
 using Robust.Shared.Timing;
 
 namespace Content.Server._Mono.Cleanup;
@@ -106,6 +107,9 @@ public abstract partial class BaseCleanupSystem<TComp> : EntitySystem
 
     protected void CleanupEnt(EntityUid uid)
     {
+        // don't delete it if claimed
+        if (TryComp<ClaimableGridComponent>(uid, out var claimable) && claimable.Claimed)   /// Forge-Change
+            return;
         var coord = Transform(uid).Coordinates;
         var world = _transform.ToMapCoordinates(coord);
         if (_doLog)


### PR DESCRIPTION
## О PR
Баннеры работали раньше только на планетоидов и подобных объектов так как их логика реализованы были лишь в `BluespaceErrorRule.cs` которая и отвечала за создание Планетоидов и другие ивентовые объекты а также их удаление, 

Хотя Баннеры могут быть размещены и заклеймены обычные астероиды и обломки, но ничего не меняли - они всё равно исчезают стоит лишь отлететь на километр... 

По факту сделан ПР **со большей долей Copilot**(это можно увидеть в коммите `Dirty test`), но он там такую дичь мне начудил что я всё удалил и вручную переписал и он мне лишь помог найти где в коде происходит логика удаление гридов, _очень много времени и нервов с 10-тками тестов по 24 минут каждый ушло на его поиск.._

Так по сути ПР добавляет в логику 'GCQueueSystem' - _подсистема генератора мира по удалению "garbage collection entity"_, **проверку что если у объекта есть 'Claimable' компонент и 'claimable.Claimed'(у объекта больше 0 хозяев) то его удаление пропускает**, и тоже самое было реализовано в 'BaseCleanupSystem.cs' Монолитов по удаление всякого хлама из космоса каждые 15 минут.

Всё протестировано и работает как надо, баннеры после удаление, уничтожение или отвязывание перестают давать защиту гриду и он исчезает как и все другие. 

## Зачем / Баланс
Обломки и Астероиды имеют компонент Claimable и в гайдах описано что они предотвращают исчезновение размещая там баннер, хотя по факту они ничего не делают.. Теперь это работает как надо!

Теперь не будет у игроков фрустрации обустраивая себе астероид или делая из обломка шаттл обнаружить их навсегда стёртыми с карты.

## Требования
- [ ] Я прочитал(а) релевантные гайдлайны/документацию для этого PR на [нашем devwiki](https://monolith-station.github.io/mono-docs/).
- [ ] Я добавил(а) медиа в этот PR, либо для него не требуется демонстрация в игре.
- [ ] Подтверждаю, что PR либо не содержит AI-сгенерированного контента, либо этот контент соответствует нашим правилам.

**Changelog**
:cl: Gordod3
- fix: Баннеры теперь действительно предотвращают удаление астероидов и обломков! Не забудьте их закрепить и alt-кликнуть.