### PR TITLE
Закреплённые вещмешки под мостиком корректно выглядят

### DIFF
--- a/Content.Client/_NF/Storage/AnchorableStorageVisualSystem.cs
+++ b/Content.Client/_NF/Storage/AnchorableStorageVisualSystem.cs
@@ -1,0 +1,38 @@
+using Content.Shared._NF.Storage;
+using Robust.Client.GameObjects;
+using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
+
+namespace Content.Client._NF.Storage;
+
+/// <summary>
+/// Applies anchorable storage world-sprite visibility and draw depth from appearance state.
+/// </summary>
+public sealed class AnchorableStorageVisualSystem : EntitySystem
+{
+    [Dependency] private AppearanceSystem _appearance = default!;
+    [Dependency] private SpriteSystem _sprite = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AppearanceComponent, AppearanceChangeEvent>(OnAppearanceChange);
+    }
+
+    private void OnAppearanceChange(Entity<AppearanceComponent> ent, ref AppearanceChangeEvent args)
+    {
+        if (args.Sprite == null)
+            return;
+
+        UpdateVisuals(ent, args.Sprite);
+    }
+
+    private void UpdateVisuals(Entity<AppearanceComponent> ent, SpriteComponent sprite)
+    {
+        if (!_appearance.TryGetData<bool>(ent.Owner, AnchorableStorageVisuals.Anchored, out var anchored, ent.Comp))
+            return;
+
+        _sprite.SetDrawDepth((ent.Owner, sprite), anchored ? (int) DrawDepth.ThinWire : (int) DrawDepth.Items);
+        _sprite.SetVisible((ent.Owner, sprite), !anchored);
+    }
+}

--- a/Content.Client/_NF/Storage/AnchorableStorageVisualSystem.cs
+++ b/Content.Client/_NF/Storage/AnchorableStorageVisualSystem.cs
@@ -1,3 +1,4 @@
+/// Forge-Change-Start
 using Content.Shared._NF.Storage;
 using Robust.Client.GameObjects;
 using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
@@ -36,3 +37,4 @@ public sealed class AnchorableStorageVisualSystem : EntitySystem
         _sprite.SetVisible((ent.Owner, sprite), !anchored);
     }
 }
+/// Forge-Change-End

--- a/Content.Server/_NF/Storage/AnchorableStorageSystem.cs
+++ b/Content.Server/_NF/Storage/AnchorableStorageSystem.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Content.Server.Popups;
-using Content.Shared._NF.Storage;
+using Content.Shared._NF.Storage; /// Forge-Change
 using Content.Shared.Construction.Components;
 using Content.Shared.Mind.Components;
 using Content.Shared.Nyanotrasen.Item.PseudoItem;
@@ -22,57 +22,64 @@ public sealed partial class AnchorableStorageSystem : EntitySystem
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private TransformSystem _xform = default!;
     [Dependency] private SharedContainerSystem _container = default!;
-    [Dependency] private SharedAppearanceSystem _appearance = default!;
+    [Dependency] private SharedAppearanceSystem _appearance = default!; /// Forge-Change
 
     /// <inheritdoc/>
     public override void Initialize()
     {
-        base.Initialize();
+        base.Initialize();                                                                      /// Forge-Change
 
-        SubscribeLocalEvent<AnchorableStorageComponent, ComponentStartup>(OnComponentStartup);
+        SubscribeLocalEvent<AnchorableStorageComponent, ComponentStartup>(OnComponentStartup);  /// Forge-Change
         SubscribeLocalEvent<AnchorableStorageComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
         SubscribeLocalEvent<AnchorableStorageComponent, AnchorAttemptEvent>(OnAnchorAttempt);
         SubscribeLocalEvent<AnchorableStorageComponent, ContainerIsInsertingAttemptEvent>(OnInsertAttempt);
     }
-
+    /// Forge-Change-Start
     private void OnComponentStartup(Entity<AnchorableStorageComponent> ent, ref ComponentStartup args)
     {
         SetAnchoredVisuals(ent.Owner, Transform(ent.Owner).Anchored);
     }
+    /// Forge-Change-End
 
     private void OnAnchorStateChanged(Entity<AnchorableStorageComponent> ent, ref AnchorStateChangedEvent args)
     {
-        if (args.Anchored && CheckOverlap((ent, ent.Comp, Transform(ent))))
+        if (!args.Anchored)
+            return;
+
+        if (CheckOverlap((ent, ent.Comp, Transform(ent))))
         {
             _popup.PopupEntity(Loc.GetString("anchored-storage-already-present"), ent);
             _xform.Unanchor(ent, Transform(ent));
             return;
         }
 
+        /// Forge-Change-Start
         SetAnchoredVisuals(ent.Owner, args.Anchored);
 
         if (!args.Anchored)
             return;
-
+        /// Forge-Change-End
         // Eject any sapient creatures inside the storage.
         // Does not recurse down into bags in bags - player characters are the largest concern, and they'll only fit in duffelbags.
-        if (!TryComp(ent.Owner, out StorageComponent? storage))
-            return;
+        // if (!TryComp(ent.Owner, out StorageComponent? storage))              /// Forge-Change-Del
+        //     return;                                                          /// Forge-Change-Del
 
-        var entsToRemove = storage.StoredItems.Keys.Where(storedItem =>
-                HasComp<MindContainerComponent>(storedItem)
-                || HasComp<PseudoItemComponent>(storedItem)
-            ).ToList();
+        // var entsToRemove = storage.StoredItems.Keys.Where(storedItem =>      /// Forge-Change-Del
+        //         HasComp<MindContainerComponent>(storedItem)                  /// Forge-Change-Del
+        //         || HasComp<PseudoItemComponent>(storedItem)                  /// Forge-Change-Del
+        //     ).ToList();                                                      /// Forge-Change-Del
 
-        foreach (var removeUid in entsToRemove)
-            _container.RemoveEntity(ent.Owner, removeUid);
+        // foreach (var removeUid in entsToRemove)                              /// Forge-Change-Del
+        //     _container.RemoveEntity(ent.Owner, removeUid);                   /// Forge-Change-Del
     }
 
+    /// Forge-Change-Start
     private void SetAnchoredVisuals(EntityUid uid, bool anchored)
     {
         _appearance.SetData(uid, AnchorableStorageVisuals.Anchored, anchored);
     }
 
+    /// Forge-Change-End
     private void OnAnchorAttempt(Entity<AnchorableStorageComponent> ent, ref AnchorAttemptEvent args)
     {
         if (args.Cancelled)
@@ -92,11 +99,11 @@ public sealed partial class AnchorableStorageSystem : EntitySystem
             return;
 
         // Check for living things, they should not insert when anchored.
-        if (!HasComp<MindContainerComponent>(args.EntityUid) && !HasComp<PseudoItemComponent>(args.EntityUid))
-            return;
+        // if (!HasComp<MindContainerComponent>(args.EntityUid) && !HasComp<PseudoItemComponent>(args.EntityUid))   /// Forge-Change-Del
+        //     return;                                                                                              /// Forge-Change-Del
 
-        if (Transform(ent.Owner).Anchored)
-            args.Cancel();
+        // if (Transform(ent.Owner).Anchored)                                                                       /// Forge-Change-Del
+        //     args.Cancel();                                                                                       /// Forge-Change-Del
     }
 
     [PublicAPI]

--- a/Content.Server/_NF/Storage/AnchorableStorageSystem.cs
+++ b/Content.Server/_NF/Storage/AnchorableStorageSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Popups;
+using Content.Shared._NF.Storage;
 using Content.Shared.Construction.Components;
 using Content.Shared.Mind.Components;
 using Content.Shared.Nyanotrasen.Item.PseudoItem;
@@ -21,26 +22,37 @@ public sealed partial class AnchorableStorageSystem : EntitySystem
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private TransformSystem _xform = default!;
     [Dependency] private SharedContainerSystem _container = default!;
+    [Dependency] private SharedAppearanceSystem _appearance = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
     {
+        base.Initialize();
+
+        SubscribeLocalEvent<AnchorableStorageComponent, ComponentStartup>(OnComponentStartup);
         SubscribeLocalEvent<AnchorableStorageComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
         SubscribeLocalEvent<AnchorableStorageComponent, AnchorAttemptEvent>(OnAnchorAttempt);
         SubscribeLocalEvent<AnchorableStorageComponent, ContainerIsInsertingAttemptEvent>(OnInsertAttempt);
     }
 
+    private void OnComponentStartup(Entity<AnchorableStorageComponent> ent, ref ComponentStartup args)
+    {
+        SetAnchoredVisuals(ent.Owner, Transform(ent.Owner).Anchored);
+    }
+
     private void OnAnchorStateChanged(Entity<AnchorableStorageComponent> ent, ref AnchorStateChangedEvent args)
     {
-        if (!args.Anchored)
-            return;
-
-        if (CheckOverlap((ent, ent.Comp, Transform(ent))))
+        if (args.Anchored && CheckOverlap((ent, ent.Comp, Transform(ent))))
         {
             _popup.PopupEntity(Loc.GetString("anchored-storage-already-present"), ent);
             _xform.Unanchor(ent, Transform(ent));
             return;
         }
+
+        SetAnchoredVisuals(ent.Owner, args.Anchored);
+
+        if (!args.Anchored)
+            return;
 
         // Eject any sapient creatures inside the storage.
         // Does not recurse down into bags in bags - player characters are the largest concern, and they'll only fit in duffelbags.
@@ -54,6 +66,11 @@ public sealed partial class AnchorableStorageSystem : EntitySystem
 
         foreach (var removeUid in entsToRemove)
             _container.RemoveEntity(ent.Owner, removeUid);
+    }
+
+    private void SetAnchoredVisuals(EntityUid uid, bool anchored)
+    {
+        _appearance.SetData(uid, AnchorableStorageVisuals.Anchored, anchored);
     }
 
     private void OnAnchorAttempt(Entity<AnchorableStorageComponent> ent, ref AnchorAttemptEvent args)

--- a/Content.Shared/_NF/Storage/AnchorableStorageVisuals.cs
+++ b/Content.Shared/_NF/Storage/AnchorableStorageVisuals.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._NF.Storage;
+
+[Serializable, NetSerializable]
+public enum AnchorableStorageVisuals : byte
+{
+    Anchored,
+    Layer,
+}

--- a/Content.Shared/_NF/Storage/AnchorableStorageVisuals.cs
+++ b/Content.Shared/_NF/Storage/AnchorableStorageVisuals.cs
@@ -1,3 +1,4 @@
+/// Forge-Change-Start
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._NF.Storage;
@@ -8,3 +9,4 @@ public enum AnchorableStorageVisuals : byte
     Anchored,
     Layer,
 }
+/// Forge-Change-End

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/base_clothing_backpack.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/base_clothing_backpack.yml
@@ -3,6 +3,7 @@
   abstract: true
   id: NFBackpackHiddenStash
   components:
+  # Forge-Change-Start
   - type: Sprite
     layers:
     - state: icon
@@ -15,6 +16,7 @@
           False: { drawdepth: Items, visible: true }
   - type: Visibility
     layer: 1
+  # Forge-Change-End
   - type: Appearance
   - type: SubFloorHide
   - type: Anchorable

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/base_clothing_backpack.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/base_clothing_backpack.yml
@@ -3,6 +3,18 @@
   abstract: true
   id: NFBackpackHiddenStash
   components:
+  - type: Sprite
+    layers:
+    - state: icon
+      map: [ "enum.AnchorableStorageVisuals.Layer" ]
+  - type: GenericVisualizer
+    visuals:
+      enum.AnchorableStorageVisuals.Anchored:
+        enum.AnchorableStorageVisuals.Layer:
+          True: { drawdepth: ThinWire, visible: false }
+          False: { drawdepth: Items, visible: true }
+  - type: Visibility
+    layer: 1
   - type: Appearance
   - type: SubFloorHide
   - type: Anchorable


### PR DESCRIPTION
## О PR
Теперь любые схроны в виде вещмешков, рюкзаков и т.п. с компонентом `AnchorableStorageSystem` будут визуально обновляется после закрепления уходя на нижний уровень отображения, как провода или трубы, от чего они будут не поверх мостика а под ним, при наведение мыши не отображаются, но возможны для взаимодействия при нажатие пкм тем самым схрон куда доступнее и менее очевиден, _хотя визуально всё еще видно что под мостиком что-то есть._

Так же убрал логику не позволяющая в мешке содержать живых существ, теперь можно делать схрон и самому туда залезть чтобы спрятаться под мостиком.

**Со большой доле Copilot** добавил `AnchorableStorageVisuals` для хранение Енам статуса для отслеживание закрепление чтобы синхронизировать систему с серверной на клиетную часть и там он менял статус спрайта на новый уровень отображение чтобы визуально схрон отображался под мостиком а не над ним и наоборот, серверную систему модернизировал чтобы этот статус менял.

_Я хотел самого начало без кода реализовать отображение под мостиком сделав все сумки отображение под мостиком, но это выглядело странно учитывая что игрок мог случайно уронить свой рюкзак и потерять его не понимая что он провалился под мостик..._ 

## Зачем / Баланс
- Сумки итак можно прятать под плитку, что делает его совсем незаметным без сканера а под мостиком он уже заметнее, но доступнее и куда удобный в использование что даёт куда больше пространства для хранение ценных вещей на видном и при этом не очевидном месте.
- Теперь все существа могут ловко спрятаться под мостиком имея там закреплённый вещмешок в случае нападения на шаттл или облавы.

## Медиа
<img width="677" height="464" alt="image" src="https://github.com/user-attachments/assets/e32f8a62-618c-4833-8092-2a1cc62e18b6" />

## Требования
<!-- Подтвердите пункты, поставив X в скобках [X]: -->
- [ ] Я прочитал(а) релевантные гайдлайны/документацию для этого PR на [нашем devwiki](https://monolith-station.github.io/mono-docs/).
- [X] Я добавил(а) медиа в этот PR, либо для него не требуется демонстрация в игре.
- [ ] Подтверждаю, что PR либо не содержит AI-сгенерированного контента, либо этот контент соответствует нашим 
**Changelog**

:cl: Gordod3
- tweak: Схроны теперь отображаются под мостиком а не над ним.
- tweak: В схронах теперь можно прятаться если достаточно мал.