### PR TITLE
Фикс болтов 3 - Очередная попытка

### DIFF
--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Destructible;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Content.Shared.Projectiles;
+using Robust.Shared.Containers; // Forge-Change
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
@@ -17,6 +18,7 @@ public sealed partial class ProjectileSystem : SharedProjectileSystem
 
     [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] private SharedTransformSystem _transformSystem = default!;
+    [Dependency] private SharedContainerSystem _container = default!; // Forge-Change
 
     // <Mono>
     private EntityQuery<PhysicsComponent> _physQuery;
@@ -131,8 +133,14 @@ public sealed partial class ProjectileSystem : SharedProjectileSystem
         var query = EntityQueryEnumerator<ProjectileComponent, PhysicsComponent>();
         while (query.MoveNext(out var uid, out var projectileComp, out var physicsComp))
         {
-            if (projectileComp.ProjectileSpent || TerminatingOrDeleted(uid))
+            // Forge-Changed-Start
+            // SetCoordinates detaches contained entities, so only raycast projectiles that are actively in flight.
+            if (projectileComp.ProjectileSpent ||
+                TerminatingOrDeleted(uid) ||
+                (projectileComp.Weapon == null && projectileComp.OnlyCollideWhenShot) ||
+                _container.IsEntityInContainer(uid))
                 continue;
+            // Forge-Changed-End
 
             var xform = Transform(uid);
             var currentVelocity = projectileComp.RaycastResetVelocity ?? _physics.GetMapLinearVelocity(uid, physicsComp, xform);

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -102,7 +102,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
     /// <returns></returns>
     public bool ShouldRaycastProjectile(float speed)
     {
-        if (_adaptiveRaycasting && speed > _minRaycastVelocity * (_physicsTickrate / BasePhysicsTickrate))
+        if (_adaptiveRaycasting && speed > _minRaycastVelocity * ((float) _physicsTickrate / BasePhysicsTickrate)) // Forge-Change
             return true;
         else if (speed > _minRaycastVelocity)
             return true;
@@ -472,6 +472,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
             projectile.Shooter = null;
             projectile.Weapon = null;
             projectile.ProjectileSpent = false;
+            projectile.RaycastResetVelocity = null; /// Forge-Change
 
             Dirty(uid, projectile);
         }
@@ -504,6 +505,10 @@ public abstract partial class SharedProjectileSystem : EntitySystem
 
     private void PreventCollision(EntityUid uid, ProjectileComponent component, ref PreventCollideEvent args)
     {
+        // Ignore spent projectiles and ammo entities that should only collide while actively shot.
+        if (component.ProjectileSpent || (component.Weapon == null && component.OnlyCollideWhenShot))
+            return;
+                                                                                 /// Forge-Change
         // Goobstation - Crawling fix
         if (TryComp<RequireProjectileTargetComponent>(args.OtherEntity, out var requireTarget) && requireTarget.IgnoreThrow && requireTarget.Active)
             return;


### PR DESCRIPTION
## О PR
Как писал об этом в предыдущих ПР-ах, увидеть результат фикса можно лишь после мёрджа и лишь на сервере, щас посмотрел на сервере результат **"Фикс Болтов 2"** и понял что ничего не пофиксилось - всё так же все выпадает пока передвигаешься, вывод : проверка не работает, будем её корректировать пока не заработает..

**Со большей долей помощи Copilot** попытался исправить эту проблему описав ему опять закономерность и изучить полностью систему и её зависимости.. 

Он переделал проверку в более удобоваримый форму и указал на логику шлейфа пуль(Raycasting), что её работа не даёт болтам нормально работать как предмет и считает за пулю что имеет смысл ведь после [ПР](https://github.com/Monolith-Station/Monolith/pull/3968) добавляющий её 8 мая появился [баг репорт](https://discord.com/channels/1329292619834069034/1502494987164848162/1502494987164848162) 9 мая на болт в дискорде Монолита что косвенно указывает на его причастность, можно будет на крайняк его у нас ревертнуть чтобы точно выяснить, но пока пробуем починить так. 

Всё протестировано на локалке, всё работает как надо, но точно можно лишь сказать после мёрджа.

## Требования
- [ ] Я прочитал(а) релевантные гайдлайны/документацию для этого PR на [нашем devwiki](https://monolith-station.github.io/mono-docs/).
- [ ] Я добавил(а) медиа в этот PR, либо для него не требуется демонстрация в игре.
- [ ] Подтверждаю, что PR либо не содержит AI-сгенерированного контента, либо этот контент соответствует нашим правилам.

**Changelog**
:cl: Gordod3
- fix: Болты, стрелы, мини-шприцы теперь не будут выпадать из карманов или оружия.