### PR TITLE
Больше взаимодействий с гридами!

### DIFF
--- a/Content.Server/Fluids/EntitySystems/SpraySystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpraySystem.cs
@@ -9,12 +9,14 @@ using Content.Shared.Interaction;
 using Content.Shared.Timing;
 using Content.Shared.Vapor;
 using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.CCVar; /// Forge-Change
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Prototypes;
 using System.Numerics;
 using Robust.Shared.Map;
+using Robust.Shared.Configuration; /// Forge-Change
 
 namespace Content.Server.Fluids.EntitySystems;
 
@@ -30,6 +32,11 @@ public sealed partial class SpraySystem : EntitySystem
     [Dependency] private VaporSystem _vapor = default!;
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
+    /// Forge-Change-Start
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    private float _gridImpulseMultiplier;
+    /// Forge-Change-End
 
     public override void Initialize()
     {
@@ -37,6 +44,7 @@ public sealed partial class SpraySystem : EntitySystem
 
         SubscribeLocalEvent<SprayComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<SprayComponent, UserActivateInWorldEvent>(OnActivateInWorld);
+        Subs.CVar(_cfg, CCVars.GridImpulseMultiplier, UpdateGridMassMultiplier, true); /// Forge-Change
     }
 
     private void OnActivateInWorld(Entity<SprayComponent> entity, ref UserActivateInWorldEvent args)
@@ -50,7 +58,13 @@ public sealed partial class SpraySystem : EntitySystem
 
         Spray(entity, args.User, targetMapPos);
     }
+/// Forge-Change-Start
+    private void UpdateGridMassMultiplier(float value)
+    {
+        _gridImpulseMultiplier = value;
+    }
 
+/// Forge-Change-End
     private void OnAfterInteract(Entity<SprayComponent> entity, ref AfterInteractEvent args)
     {
         if (args.Handled)
@@ -156,7 +170,23 @@ public sealed partial class SpraySystem : EntitySystem
             if (TryComp<PhysicsComponent>(user, out var body))
             {
                 if (_gravity.IsWeightless(user))
-                    _physics.ApplyLinearImpulse(user, -impulseDirection.Normalized() * entity.Comp.PushbackAmount, body: body);
+                /// Forge-Change-Start
+                {
+                    // push back the player
+                    _physics.ApplyLinearImpulse(user, -impulseDirection * entity.Comp.PushbackAmount, body: body);
+                }
+                else
+                {
+                    // push back the grid the player is standing on
+                    var userTransform = Transform(user);
+                    if (userTransform.GridUid == userTransform.ParentUid)
+                    {
+                        // apply both linear and angular momentum depending on the player position
+                        // multiply by a cvar because grid mass is currently extremely small compared to all other masses
+                        _physics.ApplyLinearImpulse(userTransform.GridUid.Value, -impulseDirection * _gridImpulseMultiplier * entity.Comp.PushbackAmount, userTransform.LocalPosition);
+                    }
+                }
+                /// Forge-Change-End
             }
         }
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -56,8 +56,8 @@ public sealed partial class ShuttleSystem
     private float _sweepRadius;
 
     private const float _sparkChance = 0.2f;
-    // shuttle mass to consider the neutral point for inertia scaling
-    private const float _baseShuttleMass = 50f;
+    // shuttle mass to consider the neutral point for inertia scaling: 100 tiles at standard weight /// Forge-Change
+    private const float _baseShuttleMass = 100f * TileDensityMultiplier;                            /// Forge-Change
     // exists primarily for optimisation so not a cvar
     private const float _minImpulseVelocity = 0.07f;
     // high-speed collisions tend to be a series of increasingly smaller collisions so don't spam admin logs

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -56,7 +56,7 @@ public sealed partial class ShuttleSystem
     private float _sweepRadius;
 
     private const float _sparkChance = 0.2f;
-    // shuttle mass to consider the neutral point for inertia scaling: 100 tiles at standard weight /// Forge-Change
+    // shuttle mass to consider the neutral point for inertia scaling: 100 tiles at standard weight
     private const float _baseShuttleMass = 100f * TileDensityMultiplier;                            /// Forge-Change
     // exists primarily for optimisation so not a cvar
     private const float _minImpulseVelocity = 0.07f;

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -193,7 +193,7 @@ public sealed partial class CCVars
     ///         At the moment they have a very low mass of roughly 0.48 kg per tile independent of any walls or anchored objects on them.
     /// </summary>
     public static readonly CVarDef<float> GridImpulseMultiplier =
-        CVarDef.Create("shuttle.grid_impulse_multiplier", 0.01f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.grid_impulse_multiplier", 0.04f, CVar.SERVERONLY); /// Forge-Change
 
     #region impacts
 

--- a/Content.Shared/Gravity/GravityAffectedComponent.cs
+++ b/Content.Shared/Gravity/GravityAffectedComponent.cs
@@ -14,4 +14,13 @@ public sealed partial class GravityAffectedComponent : Component
     /// </summary>
     [ViewVariables, AutoNetworkedField]
     public bool Weightless = true;
+    /// Forge-Change-Start
+
+    /// <summary>
+    /// If true, the <see cref="Weightless"/> value is currently being provided via the grid through <see cref="SharedGravitySystem.EntityGridOrMapHaveGravity"/>.
+    /// If false, the value is provided by the <see cref="IsWeightlessEvent"/>.
+    /// </summary>
+    [ViewVariables, AutoNetworkedField]
+    public bool GridWeightlessStatus = false;
+    /// Forge-Change-End
 }

--- a/Content.Shared/Gravity/SharedGravitySystem.cs
+++ b/Content.Shared/Gravity/SharedGravitySystem.cs
@@ -45,27 +45,42 @@ public abstract partial class SharedGravitySystem : EntitySystem
         UpdateShake();
     }
 
+    /// <summary>
+    /// If the entity can be weightless and is weightless, return true, otherwise return false
+    /// </summary>
     public bool IsWeightless(Entity<GravityAffectedComponent?> entity)
     {
-        // If we can be weightless and are weightless, return true, otherwise return false
         return _weightlessQuery.Resolve(entity, ref entity.Comp, false) && entity.Comp.Weightless;
     }
+    /// Forge-Change-Start
+    /// <summary>
+    /// If the entity can be weightless and the status (whether weightless or not) is from the grid/map, return true, otherwise return false.
+    /// </summary>
+    public bool IsWeightlessStatusFromGrid(Entity<GravityAffectedComponent?> entity)
+    {
+        return _weightlessQuery.Resolve(entity, ref entity.Comp, false) && entity.Comp.GridWeightlessStatus;
+    }
 
-    private bool GetWeightless(Entity<GravityAffectedComponent, PhysicsComponent?> entity)
+    /// <summary>
+    /// Gets an entity's weightless status.
+    /// </summary>
+    /// <returns>First bool returns true if the entity is weightless. Second bool returns true if the first bool was given via the grid/map gravity, false if from the entity.</returns>
+    private (bool, bool) GetWeightless(Entity<GravityAffectedComponent, PhysicsComponent?> entity)
+    /// Forge-Change-End
     {
         if (!_physicsQuery.Resolve(entity, ref entity.Comp2, false))
-            return false;
+            return (false, false); /// Forge-Change
 
         if (entity.Comp2.BodyType is BodyType.Static or BodyType.Kinematic)
-            return false;
+            return (false, false); /// Forge-Change
 
         // Check if something other than the grid or map is overriding our gravity
         var ev = new IsWeightlessEvent();
         RaiseLocalEvent(entity, ref ev);
         if (ev.Handled)
-            return ev.IsWeightless;
+            return (ev.IsWeightless, false); /// Forge-Change
 
-        return !EntityGridOrMapHaveGravity(entity.Owner);
+        return (!EntityGridOrMapHaveGravity(entity.Owner), true); /// Forge-Change
     }
 
     /// <summary>
@@ -103,10 +118,11 @@ public abstract partial class SharedGravitySystem : EntitySystem
         var newWeightless = GetWeightless(entity);
 
         // Don't network or raise events if it's not changing
-        if (newWeightless == entity.Comp.Weightless)
+        if (newWeightless.Item1 == entity.Comp.Weightless && newWeightless.Item2 == entity.Comp.GridWeightlessStatus) /// Forge-Change
             return;
 
-        entity.Comp.Weightless = newWeightless;
+        entity.Comp.Weightless = newWeightless.Item1;           /// Forge-Change
+        entity.Comp.GridWeightlessStatus = newWeightless.Item2; /// Forge-Change
         Dirty(entity);
 
         var ev = new WeightlessnessChangedEvent(entity.Comp.Weightless);

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Atmos;
 using Content.Shared.Light.Components;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Shuttles.Systems;
 using Content.Shared.Tools;
 using Robust.Shared.Audio;
 using Robust.Shared.Map;
@@ -122,7 +123,7 @@ namespace Content.Shared.Maps
         /// Effective mass of this tile for grid impacts.
         /// </summary>
         [DataField]
-        public float Mass = 1000f;
+        public float Mass = SharedShuttleSystem.TileDensityMultiplier; /// Forge-Change
 
         // <Mono>
         /// <summary>

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -123,7 +123,7 @@ namespace Content.Shared.Maps
         /// Effective mass of this tile for grid impacts.
         /// </summary>
         [DataField]
-        public float Mass = SharedShuttleSystem.TileDensityMultiplier; /// Forge-Change
+        public float Mass = 1000f; /// Forge-Change
 
         // <Mono>
         /// <summary>

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -11,6 +11,7 @@ using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Tag;
+using Content.Shared.Projectiles;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
@@ -540,7 +541,8 @@ public abstract partial class SharedMoverController : VirtualController
                 !otherCollider.CanCollide ||
                 (collider.CollisionMask & otherCollider.CollisionLayer) == 0 &&
                 (otherCollider.CollisionMask & collider.CollisionLayer) == 0 ||
-                PullableQuery.TryComp(otherEntity, out var pullable) && pullable.BeingPulled)
+                PullableQuery.TryComp(otherEntity, out var pullable) && pullable.BeingPulled || /// Forge-Change
+                HasComp<ProjectileComponent>(otherEntity))                                      /// Forge-Change
             {
                 continue;
             }

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -131,7 +131,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
         if (!Resolve(gridUid, ref physics))
             return true;
         /// Forge-Change-Start
-        /// physics.BodyType; Forge-Change-Del
+        // physics.BodyType; /// Forge-Change-Del
 
         if (physics.BodyType != BodyType.Static && physics.Mass < (20f * TileDensityMultiplier)) // A grid of approx 20 tiles, to not draw tiny grids.
         {

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -7,8 +7,10 @@ using Content.Shared.Shuttles.UI.MapObjects;
 using Content.Shared.Whitelist;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Physics;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared.Shuttles.Systems;
 
@@ -23,6 +25,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
 
     public const float FTLRange = 0f;
     public const float FTLBufferRange = 20f;
+    public const float TileDensityMultiplier = 0.5f; /// Forge-Change
 
     private EntityQuery<MapGridComponent> _gridQuery;
     private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -127,7 +130,15 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     {
         if (!Resolve(gridUid, ref physics))
             return true;
+        /// Forge-Change-Start
+        /// physics.BodyType; Forge-Change-Del
 
+        if (physics.BodyType != BodyType.Static && physics.Mass < (20f * TileDensityMultiplier)) // A grid of approx 20 tiles, to not draw tiny grids.
+        {
+            return false;
+        }
+
+        /// Forge-Change-End
         if (!Resolve(gridUid, ref iffComp, false))
         {
             return true;

--- a/Content.Shared/Weapons/Misc/GrapplingProjectileEmbedComponent.cs
+++ b/Content.Shared/Weapons/Misc/GrapplingProjectileEmbedComponent.cs
@@ -1,0 +1,18 @@
+/// Forge-Change-Start
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Weapons.Misc;
+
+/// <summary>
+/// Component used to track that an object has a grappling projectile embeded into it, to ensure joint relays between grid and entities are properly updated.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class GrapplingProjectileEmbedComponent : Component
+{
+    /// <summary>
+    /// The projectiles embedded in this entity.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public List<EntityUid> GrapplingProjectiles = new();
+}
+/// Forge-Change-End

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -1,9 +1,8 @@
 using System.Numerics;
 using Content.Shared.CombatMode;
-using Content.Shared.Gravity;               /// Forge-Change
-using Content.Shared.Hands.EntitySystems;   /// Forge-Change
+using Content.Shared.Gravity;
 using Content.Shared.Hands;
-using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Movement.Events;
 using Content.Shared.Physics;
@@ -20,27 +19,22 @@ using Robust.Shared.Physics.Dynamics.Joints;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
-
-// Mono
-using Robust.Shared.Player;
-using Robust.Shared.GameStates;
-using System.Numerics;
+using Robust.Shared.Map.Components;
 
 namespace Content.Shared.Weapons.Misc;
 
 public abstract partial class SharedGrapplingGunSystem : VirtualController
 {
     [Dependency] protected IGameTiming Timing = default!;
-    [Dependency] private ISharedPlayerManager _player = default!;
     [Dependency] private INetManager _netManager = default!;
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
+    [Dependency] private SharedHandsSystem _hands = default!;
     [Dependency] private SharedJointSystem _joints = default!;
     [Dependency] private SharedGunSystem _gun = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
-    [Dependency] private SharedPvsOverrideSystem _pvsOverride = default!; // Mono
     [Dependency] private SharedTransformSystem _transform = default!;
-    [Dependency] private SharedGravitySystem _gravity = default!; /// Forge-Change
+    [Dependency] private SharedGravitySystem _gravity = default!;
     [Dependency] private SharedContainerSystem _container = default!;
 
     /// <summary>
@@ -48,24 +42,20 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
     /// </summary>
     public const string GrapplingJoint = "grappling";
 
-    /// Forge-Change-Start
     /// <summary>
     /// The "default" mass below which pulling strength is scaled, to prevent small entities from being yeeted too fast.
     /// </summary>
     public const float BaseWeightMass = 80f;
 
-    /// Forge-Change-End
     public override void Initialize()
     {
-        // SubscribeLocalEvent<GrapplingProjectileComponent, ProjectileEmbedEvent>(OnGrappleCollide);       /// Forge-Change-Del
         SubscribeLocalEvent<GrapplingProjectileComponent, JointRemovedEvent>(OnGrappleJointRemoved);
-        SubscribeLocalEvent<GrapplingProjectileComponent, ComponentShutdown>(OnGrappleProjectileShutdown);  /// Forge-Change
-        SubscribeLocalEvent<GrapplingProjectileComponent, ProjectileEmbedEvent>(OnGrappleCollide);          /// Forge-Change
+        SubscribeLocalEvent<GrapplingProjectileComponent, ComponentShutdown>(OnGrappleProjectileShutdown);
+        SubscribeLocalEvent<GrapplingProjectileComponent, ProjectileEmbedEvent>(OnGrappleCollide);
 
         SubscribeLocalEvent<GrapplingGunComponent, GunShotEvent>(OnGrapplingShot);
         SubscribeLocalEvent<GrapplingGunComponent, ActivateInWorldEvent>(OnGunActivate);
         SubscribeLocalEvent<GrapplingGunComponent, HandDeselectedEvent>(OnGrapplingDeselected);
-        /// Forge-Change-Start
 
         SubscribeAllEvent<RequestGrapplingReelMessage>(OnGrapplingReel);
         SubscribeLocalEvent<CanWeightlessMoveEvent>(OnWeightlessMove);
@@ -73,7 +63,6 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         // TODO: After step trigger refactor, dropping a grappling gun should manually try and activate step triggers it's suppressing.
 
         SubscribeLocalEvent<GrapplingProjectileEmbedComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
-        /// Forge-Change-End
 
         UpdatesBefore.Add(typeof(SharedJointSystem)); // We want to run before joints are solved
         base.Initialize();
@@ -84,26 +73,25 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         if (_netManager.IsServer)
             QueueDel(uid);
     }
-    /// Forge-Change-Start
-    private void OnGrappleProjectileShutdown(EntityUid uid, GrapplingProjectileComponent component, ComponentShutdown args)
+
+    private void OnGrappleProjectileShutdown(Entity<GrapplingProjectileComponent> ent, ref ComponentShutdown args)
     {
-        if (!TryComp<EmbeddableProjectileComponent>(uid, out var embedComp) || embedComp.EmbeddedIntoUid == null)
+        if (!TryComp<EmbeddableProjectileComponent>(ent, out var embedComp) || embedComp.EmbeddedIntoUid == null)
             return;
 
         if (!TryComp<GrapplingProjectileEmbedComponent>(embedComp.EmbeddedIntoUid, out var grapplingEmbedComp))
             return;
 
-        grapplingEmbedComp.GrapplingProjectiles.Remove(uid);
+        grapplingEmbedComp.GrapplingProjectiles.Remove(ent);
     }
 
     private void OnGrappleCollide(EntityUid uid, GrapplingProjectileComponent component, ref ProjectileEmbedEvent args)
     {
-        if (!Timing.IsFirstTimePredicted || !TryComp<GrapplingGunComponent>(args.Weapon, out var grapple))
+        if (!Timing.IsFirstTimePredicted || args.Weapon == null || !TryComp<GrapplingGunComponent>(args.Weapon, out var grapple))
             return;
-
         var grapplePos = _transform.GetWorldPosition(args.Weapon);
         var hookPos = _transform.GetWorldPosition(uid);
-        if (grapple.RopeMaxLength is { } ropeMaxLength && (grapplePos - hookPos).Length() >= ropeMaxLength)
+        if ((grapplePos - hookPos).Length() >= grapple.RopeMaxLength)
         {
             Ungrapple((args.Weapon, grapple), true);
             return;
@@ -125,32 +113,37 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
 
         _joints.RefreshRelay(args.Weapon, jointCompGrapple);
     }
-    /// Forge-Change-End
 
     private void OnGrapplingShot(EntityUid uid, GrapplingGunComponent component, ref GunShotEvent args)
     {
         foreach (var (shotUid, _) in args.Ammo)
         {
-            if (shotUid is not { } shot || !HasComp<GrapplingProjectileComponent>(shotUid))
+            if (!HasComp<GrapplingProjectileComponent>(shotUid))
                 continue;
 
             //todo: this doesn't actually support multigrapple
             // At least show the visuals.
-            component.Projectile = shot;
+            component.Projectile = shotUid.Value;
             DirtyField(uid, component, nameof(GrapplingGunComponent.Projectile));
-            var visuals = EnsureComp<JointVisualsComponent>(shot);
+            var visuals = EnsureComp<JointVisualsComponent>(shotUid.Value);
             visuals.Sprite = component.RopeSprite;
-            visuals.OffsetA = new Vector2(0f, 0.5f);
             visuals.Target = GetNetEntity(uid);
-            Dirty(shot, visuals);
-
-            // Mono
-            if (_player.TryGetSessionByEntity(args.User, out var session))
-                _pvsOverride.AddSessionOverride(shot, session);
+            Dirty(shotUid.Value, visuals);
         }
 
         TryComp<AppearanceComponent>(uid, out var appearance);
         _appearance.SetData(uid, SharedTetherGunSystem.TetherVisualsStatus.Key, false, appearance);
+    }
+
+    private void OnGunActivate(EntityUid uid, GrapplingGunComponent component, ActivateInWorldEvent args)
+    {
+        if (!Timing.IsFirstTimePredicted || args.Handled || !args.Complex)
+            return;
+
+        _audio.PlayPredicted(component.CycleSound, uid, args.User);
+        Ungrapple((uid, component), false, args.User);
+
+        args.Handled = true;
     }
 
     private void OnGrapplingDeselected(EntityUid uid, GrapplingGunComponent component, HandDeselectedEvent args)
@@ -160,9 +153,11 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
 
     private void OnGrapplingReel(RequestGrapplingReelMessage msg, EntitySessionEventArgs args)
     {
-        var player = args.SenderSession.AttachedEntity;
-        if (!TryComp<HandsComponent>(player, out var hands) ||
-            !TryComp<GrapplingGunComponent>(hands.ActiveHandEntity, out var grappling))
+        if (args.SenderSession.AttachedEntity is not { } player)
+            return;
+
+        if (!_hands.TryGetActiveItem(player, out var activeItem) ||
+            !TryComp<GrapplingGunComponent>(activeItem, out var grappling))
         {
             return;
         }
@@ -174,7 +169,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             return;
         }
 
-        SetReeling(hands.ActiveHandEntity.Value, grappling, msg.Reeling, player.Value);
+        SetReeling(activeItem.Value, grappling, msg.Reeling, player);
     }
 
     private void OnWeightlessMove(ref CanWeightlessMoveEvent ev)
@@ -186,12 +181,16 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         {
             if (TryComp<JointComponent>(relay, out var jointRelay) && jointRelay.GetJoints.ContainsKey(GrapplingJoint))
             {
-                ev.CanMove = true;
+                if(jointRelay.GetJoints.TryGetValue(GrapplingJoint, out var joint))
+                {
+                    var grid = _transform.GetGrid(joint.BodyAUid);
+                    if (grid is not null)
+                        ev.CanMove = true;
+                }
                 return;
             }
         }
     }
-    /// Forge-Change-Start
 
     private void OnAnchorStateChanged(Entity<GrapplingProjectileEmbedComponent> entity, ref AnchorStateChangedEvent args)
     {
@@ -206,7 +205,6 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             RefreshJointRelay(entity);
         }
     }
-    /// Forge-Change-End
 
     /// <summary>
     /// Ungrapples the grappling hook, destroying the hook and severing the joint
@@ -219,7 +217,6 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         if (!Timing.IsFirstTimePredicted || grapple.Comp.Projectile is not { } projectile)
             return;
 
-        /// Forge-Change-Start
         if (isBreak)
         {
             if (user != null)
@@ -227,7 +224,6 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             else if (_netManager.IsServer) // This feels... hacky.
                 _audio.PlayPvs(grapple.Comp.BreakSound, grapple.Owner);
         }
-        /// Forge-Change-End
 
         _appearance.SetData(grapple.Owner, SharedTetherGunSystem.TetherVisualsStatus.Key, true);
 
@@ -238,17 +234,6 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         grapple.Comp.Projectile = null;
         DirtyField(grapple.Owner, grapple.Comp, nameof(GrapplingGunComponent.Projectile));
         _gun.ChangeBasicEntityAmmoCount(grapple.Owner, 1);
-    }
-
-    private void OnGunActivate(EntityUid uid, GrapplingGunComponent component, ActivateInWorldEvent args)
-    {
-        if (!Timing.IsFirstTimePredicted || args.Handled || !args.Complex)
-            return;
-
-        _audio.PlayPredicted(component.CycleSound, uid, args.User);
-        Ungrapple((uid, component), false, args.User);
-
-        args.Handled = true;
     }
 
     private void SetReeling(EntityUid uid, GrapplingGunComponent component, bool value, EntityUid? user)
@@ -267,10 +252,11 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         if (value)
         {
             // We null-coalesce here because playing the sound again will cause it to become eternally stuck playing
-            component.Stream ??= _audio.PlayPredicted(component.ReelSound, uid, user)?.Entity ?? component.Stream;
+            component.Stream ??= _audio.PlayPredicted(component.ReelSound, uid, user)?.Entity;
         }
         else if (!value && component.Stream.HasValue && Timing.IsFirstTimePredicted)
         {
+            // The IsFirstTimePredicted check is important here because otherwise component.Stream will be set to null from an early cancellation if this isn't FirstTimePredicted
             component.Stream = _audio.Stop(component.Stream);
         }
 
@@ -303,8 +289,8 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                 continue;
             }
 
-            var physicalGrapple = jointComp.Relay ?? joint.BodyBUid;
-            var physicalHook = hookJointComp.Relay ?? joint.BodyAUid;
+            var physicalGrapple = jointComp.Relay.HasValue ? jointComp.Relay.Value : joint.BodyBUid;
+            var physicalHook = hookJointComp.Relay.HasValue ? hookJointComp.Relay.Value : joint.BodyAUid;
 
             // HACK: preventing both ends of the grappling hook from sleeping if neither are on the same grid, so that grid movement works as expected
             if (_transform.GetGrid(physicalHook) != _transform.GetGrid(physicalGrapple))
@@ -314,20 +300,14 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             }
             // END OF HACK
 
-            var bodyAWorldPos = _transform.GetWorldPosition(joint.BodyAUid); /// Forge-Change
-            var bodyBWorldPos = _transform.GetWorldPosition(joint.BodyBUid); /// Forge-Change
-
-            // Mono
-            var bodyAVel = _physics.GetMapLinearVelocity(physicalHook);
-            var bodyBVel = _physics.GetMapLinearVelocity(physicalGrapple);
-            var velDiff = bodyAVel - bodyBVel;
-            var margin = grappling.RopeMargin + velDiff.Length() * frameTime; // Mono
+            var bodyAWorldPos = _transform.GetWorldPosition(joint.BodyAUid);
+            var bodyBWorldPos = _transform.GetWorldPosition(joint.BodyBUid);
 
             // The solver does not handle setting the rope's length, but we still need to work with a copy of it to prevent jank.
             var ropeLength = (bodyAWorldPos - bodyBWorldPos).Length();
 
             // Rope should just break, instantly, if the user is teleported past its max length
-            if (ropeLength >= distance.MaxLength + margin)
+            if (ropeLength >= distance.MaxLength + grappling.RopeMargin)
             {
                 Ungrapple((uid, grappling), true);
                 continue;
@@ -342,25 +322,23 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                 continue;
             }
 
-
             // TODO: Contracting DistanceJoints should be in engine
-            if (distance.MaxLength >= ropeLength + margin)
+            if (distance.MaxLength >= ropeLength + grappling.RopeMargin)
             {
-                distance.MaxLength = MathF.Max(distance.MinLength + margin, distance.MaxLength - grappling.ReelRate * frameTime);
-                distance.MaxLength = MathF.Max(ropeLength + margin, distance.MaxLength);
+                distance.MaxLength = MathF.Max(distance.MinLength + grappling.RopeMargin, distance.MaxLength - grappling.ReelRate * frameTime);
+                distance.MaxLength = MathF.Max(ropeLength + grappling.RopeMargin, distance.MaxLength);
                 ropeLength = MathF.Min(distance.MaxLength, ropeLength);
 
                 distance.Length = ropeLength;
             }
 
+
             if (ropeLength <= distance.MinLength + grappling.RopeFullyReeledMargin)
             {
                 SetReeling(uid, grappling, false, null);
             }
-            else if (ropeLength >= distance.MaxLength - margin)
+            else if (ropeLength >= distance.MaxLength - grappling.RopeMargin)
             {
-                /// Forge-Change-Start
-
                 // Checks if the entity is "tied" to the grid it is on via extra-gravity technology (e.g. magboots). If so, for the purposes of reeling it counts as if you're weighing the same as the grid.
                 bool attachedToGrid;
 
@@ -385,38 +363,39 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                     }
                 }
 
-                /// Forge-Change-End
                 var targetDirection = (bodyAWorldPos - bodyBWorldPos).Normalized();
 
                 var grapplerUidA = _container.TryGetOuterContainer(physicalHook, Transform(physicalHook), out var containerA) ? containerA.Owner : physicalHook;
-                var grapplerOffsetA = _transform.GetRelativePosition(Transform(joint.BodyAUid), grapplerUidA); /// Forge-Change
+                var grapplerOffsetA = _transform.GetRelativePosition(Transform(joint.BodyAUid), grapplerUidA);
                 var grapplerBodyA = Comp<PhysicsComponent>(grapplerUidA);
 
-                // _physics.ApplyLinearImpulse(grapplerUidA, targetDirection * grappling.ReelForce * frameTime * -1, body: grapplerBodyA); /// Forge-Change-Del
-
                 var grapplerUidB = _container.TryGetOuterContainer(physicalGrapple, Transform(physicalGrapple), out var containerB) ? containerB.Owner : physicalGrapple;
-                /// Forge-Change-Start
                 if (attachedToGrid)
                     grapplerUidB = _transform.GetGrid(joint.BodyBUid) ?? grapplerUidB;
                 var grapplerOffsetB = _transform.GetRelativePosition(Transform(joint.BodyBUid), grapplerUidB);
-                /// Forge-Change-End
                 var grapplerBodyB = Comp<PhysicsComponent>(grapplerUidB);
 
-                // _physics.ApplyLinearImpulse(grapplerUidB, targetDirection * grappling.ReelForce * frameTime, body: grapplerBodyB); /// Forge-Change-Del
-                /// Forge-Change-Start
                 // Handle edge-cases where the mass is zero (e.g. station anchor). Treat that as infinite weight.
                 float massFactor;
                 if (grapplerBodyA.Mass == 0f && grapplerBodyB.Mass != 0f)
                 {
-                    massFactor = 1f;
+                    massFactor = 0.5f;
                 }
                 else if (grapplerBodyA.Mass != 0f && grapplerBodyB.Mass == 0f)
                 {
-                    massFactor = 0f;
+                    massFactor = 1f;
                 }
                 else if (grapplerBodyA.Mass == 0f && grapplerBodyB.Mass == 0f)
                 {
-                    massFactor = 0.5f;
+                    massFactor = 1f;
+                }
+                else if(grapplerBodyA.Mass <= 8f && grapplerBodyB.Mass >= 130f)
+                {
+                    massFactor = 0f;
+                }
+                else if(grapplerBodyA.Mass >= 8f && grapplerBodyB.Mass <= 130f)
+                {
+                    massFactor = 1f;
                 }
                 else
                 {
@@ -432,21 +411,52 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                 if (grapplerBodyA.Mass < BaseWeightMass) // To prevent small things go zoomies
                     massFactorA *= grapplerBodyA.Mass / BaseWeightMass;
 
-                _physics.ApplyLinearImpulse(grapplerUidA, targetDirection * massFactorA * grappling.ReelForce * frameTime * -1, grapplerOffsetA, body: grapplerBodyA);
+                // Prevent applying impulses if rope is ended to prevent cliping to the walls from space and applying it while standing on the same grid
+                if (!(ropeLength <= 5f) && !HasComp<MapGridComponent>(grapplerUidA))
+                {
+                    massFactorA += 0.5f;
+                    _physics.ApplyLinearImpulse(grapplerUidA, targetDirection * massFactorA * grappling.ReelForce * frameTime * -1, grapplerOffsetA, body: grapplerBodyA);
+                }
+                else if (ropeLength >= 150f && _transform.GetGrid(joint.BodyAUid) != _transform.GetGrid(joint.BodyBUid))
+                {
+                    _physics.ApplyLinearImpulse(grapplerUidA, targetDirection * massFactorA * grappling.ReelForce * frameTime * -1, grapplerOffsetA, body: grapplerBodyA);
+                }
 
                 var massFactorB = massFactor;
                 if (grapplerBodyB.Mass < BaseWeightMass) // To prevent small things go zoomies
                     massFactorB *= grapplerBodyB.Mass / BaseWeightMass;
-
-                _physics.ApplyLinearImpulse(grapplerUidB, targetDirection * massFactorB * grappling.ReelForce * frameTime, grapplerOffsetB, body: grapplerBodyB);
-                /// Forge-Change-End
+                Log.Info($"grappling Mass: A={grapplerBodyA.Mass}, B={grapplerBodyB.Mass}");
+                Log.Info($"grappling Grid GrappleUID: A={ToPrettyString(grapplerUidA)}, B={ToPrettyString(grapplerUidB)}");
+                Log.Info($"grappling Grid GrappleUID: A={ToPrettyString(_transform.GetGrid(joint.BodyAUid))}, B={ToPrettyString(_transform.GetGrid(joint.BodyBUid))}");
+                Log.Info($"grappling MassFactor: A={massFactorA}, B={massFactorB}");
+                // Prevent applying impulses if rope is ended to prevent cliping to the walls
+                if(ropeLength >= 5f)
+                    _physics.ApplyLinearImpulse(grapplerUidB, targetDirection * massFactorB * grappling.ReelForce * frameTime, grapplerOffsetB, body: grapplerBodyB);
             }
 
             Dirty(uid, jointComp);
         }
     }
 
-    /// Forge-Change-Start
+    /// <summary>
+    /// Checks whether the entity is hooked to something via grappling gun.
+    /// </summary>
+    /// <param name="entity">Entity to check.</param>
+    /// <returns>True if hooked, false otherwise.</returns>
+    public bool IsEntityHooked(Entity<JointRelayTargetComponent?> entity)
+    {
+        if (!Resolve(entity, ref entity.Comp, false))
+            return false;
+
+        foreach (var uid in entity.Comp.Relayed)
+        {
+            if (HasComp<GrapplingGunComponent>(uid))
+                return true;
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// Updates the relay of any grappling hook to ensure it uses either the embedded entity, or the grid if the entity is anchored.
     /// </summary>
@@ -474,7 +484,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         }
     }
 
-    /// Forge-Change-End
+
     [Serializable, NetSerializable]
     protected sealed class RequestGrapplingReelMessage : EntityEventArgs
     {

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -341,28 +341,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             else if (ropeLength >= distance.MaxLength - grappling.RopeMargin)
             {
                 // Checks if the entity is "tied" to the grid it is on via extra-gravity technology (e.g. magboots). If so, for the purposes of reeling it counts as if you're weighing the same as the grid.
-                bool attachedToGrid;
-
-                if (_transform.GetGrid(joint.BodyAUid) == _transform.GetGrid(joint.BodyBUid))
-                {
-                    attachedToGrid = false;
-                }
-                else
-                {
-                    if (jointComp.Relay != null)
-                    {
-                        _physics.WakeBody(jointComp.Relay.Value);
-                        attachedToGrid = Transform(jointComp.Relay.Value).Anchored ||
-                                         !_gravity.IsWeightless(jointComp.Relay.Value) &&
-                                         !_gravity.IsWeightlessStatusFromGrid(jointComp.Relay.Value);
-                    }
-                    else
-                    {
-                        attachedToGrid = Transform(joint.BodyAUid).Anchored ||
-                                         !_gravity.IsWeightless(joint.BodyAUid) &&
-                                         !_gravity.IsWeightlessStatusFromGrid(joint.BodyAUid);
-                    }
-                }
+                bool attachedToGrid = ToGridAttached(jointComp, joint);
 
                 var targetDirection = (bodyAWorldPos - bodyBWorldPos).Normalized();
 
@@ -418,7 +397,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                     massFactorA += 0.5f;
                     _physics.ApplyLinearImpulse(grapplerUidA, targetDirection * massFactorA * grappling.ReelForce * frameTime * -1, grapplerOffsetA, body: grapplerBodyA);
                 }
-                else if (ropeLength >= 150f && _transform.GetGrid(joint.BodyAUid) != _transform.GetGrid(joint.BodyBUid))
+                else if (ropeLength >= 150f && _transform.GetGrid(joint.BodyAUid) != _transform.GetGrid(joint.BodyBUid) && StandingOnGrid(joint.BodyBUid))
                 {
                     _physics.ApplyLinearImpulse(grapplerUidA, targetDirection * massFactorA * grappling.ReelForce * frameTime * -1, grapplerOffsetA, body: grapplerBodyA);
                 }
@@ -428,11 +407,16 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                     massFactorB *= grapplerBodyB.Mass / BaseWeightMass;
                 Log.Info($"grappling Mass: A={grapplerBodyA.Mass}, B={grapplerBodyB.Mass}");
                 Log.Info($"grappling Grid GrappleUID: A={ToPrettyString(grapplerUidA)}, B={ToPrettyString(grapplerUidB)}");
-                Log.Info($"grappling Grid GrappleUID: A={ToPrettyString(_transform.GetGrid(joint.BodyAUid))}, B={ToPrettyString(_transform.GetGrid(joint.BodyBUid))}");
+                Log.Info($"grappling Grid _transform.GetGrid: A={ToPrettyString(_transform.GetGrid(joint.BodyAUid))}, B={ToPrettyString(_transform.GetGrid(joint.BodyBUid))}");
                 Log.Info($"grappling MassFactor: A={massFactorA}, B={massFactorB}");
+                Log.Info($"grappling Transform: A={Transform(joint.BodyAUid).GridUid}, A-alt={Transform(joint.BodyAUid).ParentUid}");
                 // Prevent applying impulses if rope is ended to prevent cliping to the walls
-                if(ropeLength >= 5f)
+                if(ropeLength >= 5f && !HasComp<MapGridComponent>(grapplerUidB))
                     _physics.ApplyLinearImpulse(grapplerUidB, targetDirection * massFactorB * grappling.ReelForce * frameTime, grapplerOffsetB, body: grapplerBodyB);
+                else if (ropeLength >= 150f && _transform.GetGrid(joint.BodyAUid) != _transform.GetGrid(joint.BodyBUid) && StandingOnGrid(joint.BodyBUid))
+                {
+                    _physics.ApplyLinearImpulse(grapplerUidB, targetDirection * massFactorB * grappling.ReelForce * frameTime, grapplerOffsetB, body: grapplerBodyB);
+                }
             }
 
             Dirty(uid, jointComp);
@@ -471,7 +455,7 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             if (!jointComp.GetJoints.TryGetValue(GrapplingJoint, out var joint))
                 continue;
 
-            if (Transform(entity).Anchored && _transform.GetGrid(entity.Owner) != null)
+            if (Transform(entity).Anchored && _transform.GetGrid(entity.Owner) != null && ToGridAttached(jointComp, joint) && StandingOnGrid(joint.BodyBUid))
             {
                 joint.LocalAnchorA = _transform.GetRelativePosition(Transform(hook), _transform.GetGrid(entity.Owner)!.Value);
                 _joints.SetRelay(hook, _transform.GetGrid(entity.Owner));
@@ -483,6 +467,50 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                 _joints.SetRelay(hook, entity.Owner, jointComp);
             }
         }
+    }
+
+    /// <summary>
+    /// Checks if the entity is "tied" to the grid it is on via extra-gravity technology (e.g. magboots). If so, for the purposes of reeling it counts as if you're weighing the same as the grid.
+    /// </summary>
+    private bool ToGridAttached(JointComponent jointComp, Joint joint)
+    {
+        bool attachedToGrid;
+
+        if (_transform.GetGrid(joint.BodyAUid) == _transform.GetGrid(joint.BodyBUid))
+        {
+            attachedToGrid = false;
+        }
+        else
+        {
+            if (jointComp.Relay != null)
+            {
+                _physics.WakeBody(jointComp.Relay.Value);
+                attachedToGrid = Transform(jointComp.Relay.Value).Anchored ||
+                                    !_gravity.IsWeightless(jointComp.Relay.Value) &&
+                                    !_gravity.IsWeightlessStatusFromGrid(jointComp.Relay.Value);
+            }
+            else
+            {
+                attachedToGrid = Transform(joint.BodyAUid).Anchored ||
+                                    !_gravity.IsWeightless(joint.BodyAUid) &&
+                                    !_gravity.IsWeightlessStatusFromGrid(joint.BodyAUid);
+            }
+        }
+        return attachedToGrid;
+    }
+
+    private bool StandingOnGrid(EntityUid? entityUid)
+    {
+        if (entityUid != null &&
+            TryComp<GunComponent>(entityUid, out var gunComp) &&
+            gunComp.Holder != null &&
+            TryComp<TransformComponent>(gunComp.Holder, out var userTransform))
+            if (userTransform.GridUid == userTransform.ParentUid &&
+                TryComp<GravityAffectedComponent>(gunComp.Holder, out var gravityComp) &&
+                !(gravityComp.GridWeightlessStatus && gravityComp.Weightless))
+                return true;
+
+        return false;
     }
 
 

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -405,11 +405,6 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                 var massFactorB = massFactor;
                 if (grapplerBodyB.Mass < BaseWeightMass) // To prevent small things go zoomies
                     massFactorB *= grapplerBodyB.Mass / BaseWeightMass;
-                Log.Info($"grappling Mass: A={grapplerBodyA.Mass}, B={grapplerBodyB.Mass}");
-                Log.Info($"grappling Grid GrappleUID: A={ToPrettyString(grapplerUidA)}, B={ToPrettyString(grapplerUidB)}");
-                Log.Info($"grappling Grid _transform.GetGrid: A={ToPrettyString(_transform.GetGrid(joint.BodyAUid))}, B={ToPrettyString(_transform.GetGrid(joint.BodyBUid))}");
-                Log.Info($"grappling MassFactor: A={massFactorA}, B={massFactorB}");
-                Log.Info($"grappling Transform: A={Transform(joint.BodyAUid).GridUid}, A-alt={Transform(joint.BodyAUid).ParentUid}");
                 // Prevent applying impulses if rope is ended to prevent cliping to the walls
                 if(ropeLength >= 5f && !HasComp<MapGridComponent>(grapplerUidB))
                     _physics.ApplyLinearImpulse(grapplerUidB, targetDirection * massFactorB * grappling.ReelForce * frameTime, grapplerOffsetB, body: grapplerBodyB);
@@ -447,6 +442,9 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
     /// </summary>
     private void RefreshJointRelay(Entity<GrapplingProjectileEmbedComponent> entity)
     {
+        if (!_netManager.IsServer)
+            return;
+
         foreach (var hook in entity.Comp.GrapplingProjectiles)
         {
             if (!HasComp<GrapplingProjectileComponent>(hook) || !TryComp<JointComponent>(hook, out var jointComp))
@@ -455,10 +453,13 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             if (!jointComp.GetJoints.TryGetValue(GrapplingJoint, out var joint))
                 continue;
 
-            if (Transform(entity).Anchored && _transform.GetGrid(entity.Owner) != null && ToGridAttached(jointComp, joint) && StandingOnGrid(joint.BodyBUid))
+            var targetGrid = _transform.GetGrid(entity.Owner);
+            var canRelayToGrid = targetGrid != null && !IsDockedGrid(targetGrid.Value);
+
+            if (Transform(entity).Anchored && canRelayToGrid && ToGridAttached(jointComp, joint) && StandingOnGrid(joint.BodyBUid))
             {
-                joint.LocalAnchorA = _transform.GetRelativePosition(Transform(hook), _transform.GetGrid(entity.Owner)!.Value);
-                _joints.SetRelay(hook, _transform.GetGrid(entity.Owner));
+                joint.LocalAnchorA = _transform.GetRelativePosition(Transform(hook), targetGrid!.Value);
+                _joints.SetRelay(hook, targetGrid);
 
             }
             else
@@ -467,6 +468,20 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
                 _joints.SetRelay(hook, entity.Owner, jointComp);
             }
         }
+    }
+
+    private bool IsDockedGrid(EntityUid gridUid)
+    {
+        if (!TryComp<JointComponent>(gridUid, out var jointComp))
+            return false;
+
+        foreach (var joint in jointComp.GetJoints.Values)
+        {
+            if (joint.ID.StartsWith("docking", StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -1,5 +1,7 @@
 using System.Numerics;
 using Content.Shared.CombatMode;
+using Content.Shared.Gravity;               /// Forge-Change
+using Content.Shared.Hands.EntitySystems;   /// Forge-Change
 using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction;
@@ -38,20 +40,40 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
     [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] private SharedPvsOverrideSystem _pvsOverride = default!; // Mono
     [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private SharedGravitySystem _gravity = default!; /// Forge-Change
     [Dependency] private SharedContainerSystem _container = default!;
 
+    /// <summary>
+    /// Name of the joint between a grappling gun and its hook.
+    /// </summary>
     public const string GrapplingJoint = "grappling";
 
+    /// Forge-Change-Start
+    /// <summary>
+    /// The "default" mass below which pulling strength is scaled, to prevent small entities from being yeeted too fast.
+    /// </summary>
+    public const float BaseWeightMass = 80f;
+
+    /// Forge-Change-End
     public override void Initialize()
     {
-        SubscribeLocalEvent<GrapplingProjectileComponent, ProjectileEmbedEvent>(OnGrappleCollide);
+        // SubscribeLocalEvent<GrapplingProjectileComponent, ProjectileEmbedEvent>(OnGrappleCollide);       /// Forge-Change-Del
         SubscribeLocalEvent<GrapplingProjectileComponent, JointRemovedEvent>(OnGrappleJointRemoved);
-        SubscribeLocalEvent<CanWeightlessMoveEvent>(OnWeightlessMove);
-        SubscribeAllEvent<RequestGrapplingReelMessage>(OnGrapplingReel);
+        SubscribeLocalEvent<GrapplingProjectileComponent, ComponentShutdown>(OnGrappleProjectileShutdown);  /// Forge-Change
+        SubscribeLocalEvent<GrapplingProjectileComponent, ProjectileEmbedEvent>(OnGrappleCollide);          /// Forge-Change
 
         SubscribeLocalEvent<GrapplingGunComponent, GunShotEvent>(OnGrapplingShot);
         SubscribeLocalEvent<GrapplingGunComponent, ActivateInWorldEvent>(OnGunActivate);
         SubscribeLocalEvent<GrapplingGunComponent, HandDeselectedEvent>(OnGrapplingDeselected);
+        /// Forge-Change-Start
+
+        SubscribeAllEvent<RequestGrapplingReelMessage>(OnGrapplingReel);
+        SubscribeLocalEvent<CanWeightlessMoveEvent>(OnWeightlessMove);
+
+        // TODO: After step trigger refactor, dropping a grappling gun should manually try and activate step triggers it's suppressing.
+
+        SubscribeLocalEvent<GrapplingProjectileEmbedComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
+        /// Forge-Change-End
 
         UpdatesBefore.Add(typeof(SharedJointSystem)); // We want to run before joints are solved
         base.Initialize();
@@ -62,6 +84,48 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         if (_netManager.IsServer)
             QueueDel(uid);
     }
+    /// Forge-Change-Start
+    private void OnGrappleProjectileShutdown(EntityUid uid, GrapplingProjectileComponent component, ComponentShutdown args)
+    {
+        if (!TryComp<EmbeddableProjectileComponent>(uid, out var embedComp) || embedComp.EmbeddedIntoUid == null)
+            return;
+
+        if (!TryComp<GrapplingProjectileEmbedComponent>(embedComp.EmbeddedIntoUid, out var grapplingEmbedComp))
+            return;
+
+        grapplingEmbedComp.GrapplingProjectiles.Remove(uid);
+    }
+
+    private void OnGrappleCollide(EntityUid uid, GrapplingProjectileComponent component, ref ProjectileEmbedEvent args)
+    {
+        if (!Timing.IsFirstTimePredicted || !TryComp<GrapplingGunComponent>(args.Weapon, out var grapple))
+            return;
+
+        var grapplePos = _transform.GetWorldPosition(args.Weapon);
+        var hookPos = _transform.GetWorldPosition(uid);
+        if (grapple.RopeMaxLength is { } ropeMaxLength && (grapplePos - hookPos).Length() >= ropeMaxLength)
+        {
+            Ungrapple((args.Weapon, grapple), true);
+            return;
+        }
+
+        var embedComp = EnsureComp<GrapplingProjectileEmbedComponent>(args.Embedded);
+        embedComp.GrapplingProjectiles.Add(uid);
+
+        var joint = _joints.CreateDistanceJoint(uid, args.Weapon, id: GrapplingJoint);
+        joint.MaxLength = joint.Length + grapple.RopeMargin;
+        joint.Stiffness = grapple.RopeStiffness;
+        joint.MinLength = grapple.RopeMinLength; // Length of a tile to prevent pulling yourself into / through walls
+        joint.Breakpoint = grapple.RopeBreakPoint;
+
+        var jointCompGrapple = Comp<JointComponent>(args.Weapon);
+
+        // Since the grappling hook is offset from the grid, we need to update the local anchor so that the relay correctly uses the correct anchor for the grid.
+        RefreshJointRelay((args.Embedded, embedComp));
+
+        _joints.RefreshRelay(args.Weapon, jointCompGrapple);
+    }
+    /// Forge-Change-End
 
     private void OnGrapplingShot(EntityUid uid, GrapplingGunComponent component, ref GunShotEvent args)
     {
@@ -127,6 +191,22 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             }
         }
     }
+    /// Forge-Change-Start
+
+    private void OnAnchorStateChanged(Entity<GrapplingProjectileEmbedComponent> entity, ref AnchorStateChangedEvent args)
+    {
+        foreach (var hook in entity.Comp.GrapplingProjectiles)
+        {
+            if (!TryComp<ProjectileComponent>(hook, out var projectileComp) || !TryComp<JointComponent>(hook, out var jointComp))
+                continue;
+
+            if (projectileComp.Weapon == null || !TryComp<GrapplingGunComponent>(projectileComp.Weapon, out var gunComp))
+                continue;
+
+            RefreshJointRelay(entity);
+        }
+    }
+    /// Forge-Change-End
 
     /// <summary>
     /// Ungrapples the grappling hook, destroying the hook and severing the joint
@@ -139,8 +219,15 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         if (!Timing.IsFirstTimePredicted || grapple.Comp.Projectile is not { } projectile)
             return;
 
+        /// Forge-Change-Start
         if (isBreak)
-            _audio.PlayPredicted(grapple.Comp.BreakSound, grapple.Owner, user);
+        {
+            if (user != null)
+                _audio.PlayPredicted(grapple.Comp.BreakSound, grapple.Owner, user);
+            else if (_netManager.IsServer) // This feels... hacky.
+                _audio.PlayPvs(grapple.Comp.BreakSound, grapple.Owner);
+        }
+        /// Forge-Change-End
 
         _appearance.SetData(grapple.Owner, SharedTetherGunSystem.TetherVisualsStatus.Key, true);
 
@@ -227,8 +314,8 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             }
             // END OF HACK
 
-            var bodyAWorldPos = _transform.GetWorldPosition(physicalHook);
-            var bodyBWorldPos = _transform.GetWorldPosition(physicalGrapple);
+            var bodyAWorldPos = _transform.GetWorldPosition(joint.BodyAUid); /// Forge-Change
+            var bodyBWorldPos = _transform.GetWorldPosition(joint.BodyBUid); /// Forge-Change
 
             // Mono
             var bodyAVel = _physics.GetMapLinearVelocity(physicalHook);
@@ -272,50 +359,122 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
             }
             else if (ropeLength >= distance.MaxLength - margin)
             {
+                /// Forge-Change-Start
+
+                // Checks if the entity is "tied" to the grid it is on via extra-gravity technology (e.g. magboots). If so, for the purposes of reeling it counts as if you're weighing the same as the grid.
+                bool attachedToGrid;
+
+                if (_transform.GetGrid(joint.BodyAUid) == _transform.GetGrid(joint.BodyBUid))
+                {
+                    attachedToGrid = false;
+                }
+                else
+                {
+                    if (jointComp.Relay != null)
+                    {
+                        _physics.WakeBody(jointComp.Relay.Value);
+                        attachedToGrid = Transform(jointComp.Relay.Value).Anchored ||
+                                         !_gravity.IsWeightless(jointComp.Relay.Value) &&
+                                         !_gravity.IsWeightlessStatusFromGrid(jointComp.Relay.Value);
+                    }
+                    else
+                    {
+                        attachedToGrid = Transform(joint.BodyAUid).Anchored ||
+                                         !_gravity.IsWeightless(joint.BodyAUid) &&
+                                         !_gravity.IsWeightlessStatusFromGrid(joint.BodyAUid);
+                    }
+                }
+
+                /// Forge-Change-End
                 var targetDirection = (bodyAWorldPos - bodyBWorldPos).Normalized();
 
                 var grapplerUidA = _container.TryGetOuterContainer(physicalHook, Transform(physicalHook), out var containerA) ? containerA.Owner : physicalHook;
+                var grapplerOffsetA = _transform.GetRelativePosition(Transform(joint.BodyAUid), grapplerUidA); /// Forge-Change
                 var grapplerBodyA = Comp<PhysicsComponent>(grapplerUidA);
 
-                _physics.ApplyLinearImpulse(grapplerUidA, targetDirection * grappling.ReelForce * frameTime * -1, body: grapplerBodyA);
+                // _physics.ApplyLinearImpulse(grapplerUidA, targetDirection * grappling.ReelForce * frameTime * -1, body: grapplerBodyA); /// Forge-Change-Del
 
                 var grapplerUidB = _container.TryGetOuterContainer(physicalGrapple, Transform(physicalGrapple), out var containerB) ? containerB.Owner : physicalGrapple;
+                /// Forge-Change-Start
+                if (attachedToGrid)
+                    grapplerUidB = _transform.GetGrid(joint.BodyBUid) ?? grapplerUidB;
+                var grapplerOffsetB = _transform.GetRelativePosition(Transform(joint.BodyBUid), grapplerUidB);
+                /// Forge-Change-End
                 var grapplerBodyB = Comp<PhysicsComponent>(grapplerUidB);
 
-                _physics.ApplyLinearImpulse(grapplerUidB, targetDirection * grappling.ReelForce * frameTime, body: grapplerBodyB);
+                // _physics.ApplyLinearImpulse(grapplerUidB, targetDirection * grappling.ReelForce * frameTime, body: grapplerBodyB); /// Forge-Change-Del
+                /// Forge-Change-Start
+                // Handle edge-cases where the mass is zero (e.g. station anchor). Treat that as infinite weight.
+                float massFactor;
+                if (grapplerBodyA.Mass == 0f && grapplerBodyB.Mass != 0f)
+                {
+                    massFactor = 1f;
+                }
+                else if (grapplerBodyA.Mass != 0f && grapplerBodyB.Mass == 0f)
+                {
+                    massFactor = 0f;
+                }
+                else if (grapplerBodyA.Mass == 0f && grapplerBodyB.Mass == 0f)
+                {
+                    massFactor = 0.5f;
+                }
+                else
+                {
+                    // This assumes the bodies can move freely.
+                    // It would be nice if any resisting force applied to the grid (e.g. if stuck on something and can't move closer) would transfer to the main entity.
+                    massFactor = grapplerBodyA.Mass / (grapplerBodyA.Mass + grapplerBodyB.Mass);
+                }
+
+                // Note that this way of calculating the impulse does not take into account objects being stuck on things, e.g. a movable grapple point stuck behind a wall.
+                // Ideally the contraction of the joint itself should take this into account, but alas, this works for now.
+
+                var massFactorA = (1 - massFactor);
+                if (grapplerBodyA.Mass < BaseWeightMass) // To prevent small things go zoomies
+                    massFactorA *= grapplerBodyA.Mass / BaseWeightMass;
+
+                _physics.ApplyLinearImpulse(grapplerUidA, targetDirection * massFactorA * grappling.ReelForce * frameTime * -1, grapplerOffsetA, body: grapplerBodyA);
+
+                var massFactorB = massFactor;
+                if (grapplerBodyB.Mass < BaseWeightMass) // To prevent small things go zoomies
+                    massFactorB *= grapplerBodyB.Mass / BaseWeightMass;
+
+                _physics.ApplyLinearImpulse(grapplerUidB, targetDirection * massFactorB * grappling.ReelForce * frameTime, grapplerOffsetB, body: grapplerBodyB);
+                /// Forge-Change-End
             }
 
             Dirty(uid, jointComp);
         }
     }
 
-    private void OnGrappleCollide(EntityUid uid, GrapplingProjectileComponent component, ref ProjectileEmbedEvent args)
+    /// Forge-Change-Start
+    /// <summary>
+    /// Updates the relay of any grappling hook to ensure it uses either the embedded entity, or the grid if the entity is anchored.
+    /// </summary>
+    private void RefreshJointRelay(Entity<GrapplingProjectileEmbedComponent> entity)
     {
-        if (!Timing.IsFirstTimePredicted || !TryComp<GrapplingGunComponent>(args.Weapon, out var grapple))
-            return;
-
-
-        var grapplePos = _transform.GetWorldPosition(args.Weapon);
-        var hookPos = _transform.GetWorldPosition(uid);
-        if ((grapplePos - hookPos).Length() >= grapple.RopeMaxLength)
+        foreach (var hook in entity.Comp.GrapplingProjectiles)
         {
-            Ungrapple((args.Weapon, grapple), true);
-            return;
+            if (!HasComp<GrapplingProjectileComponent>(hook) || !TryComp<JointComponent>(hook, out var jointComp))
+                continue;
+
+            if (!jointComp.GetJoints.TryGetValue(GrapplingJoint, out var joint))
+                continue;
+
+            if (Transform(entity).Anchored && _transform.GetGrid(entity.Owner) != null)
+            {
+                joint.LocalAnchorA = _transform.GetRelativePosition(Transform(hook), _transform.GetGrid(entity.Owner)!.Value);
+                _joints.SetRelay(hook, _transform.GetGrid(entity.Owner));
+
+            }
+            else
+            {
+                joint.LocalAnchorA = Vector2.Zero;
+                _joints.SetRelay(hook, entity.Owner, jointComp);
+            }
         }
-
-        var joint = _joints.CreateDistanceJoint(uid, args.Weapon, id: GrapplingJoint);
-        joint.MaxLength = joint.Length + grapple.RopeMargin;
-        joint.Stiffness = grapple.RopeStiffness;
-        joint.MinLength = grapple.RopeMinLength; // Length of a tile to prevent pulling yourself into / through walls
-        joint.Breakpoint = grapple.RopeBreakPoint;
-
-        var jointCompHook = Comp<JointComponent>(uid); // we use get here because if the component doesn't exist then something has fucked up bigtime
-        var jointCompGrapple = Comp<JointComponent>(args.Weapon);
-
-        _joints.SetRelay(uid, args.Embedded, jointCompHook);
-        _joints.RefreshRelay(args.Weapon, jointCompGrapple);
     }
 
+    /// Forge-Change-End
     [Serializable, NetSerializable]
     protected sealed class RequestGrapplingReelMessage : EntityEventArgs
     {

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -1,3 +1,4 @@
+/// Forge-Change-Start
 using System.Numerics;
 using Content.Shared.CombatMode;
 using Content.Shared.Gravity;
@@ -496,3 +497,5 @@ public abstract partial class SharedGrapplingGunSystem : VirtualController
         }
     }
 }
+/// Forge-Change-End
+///

--- a/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
@@ -37,7 +37,7 @@ public sealed partial class GrapplingGunComponent : Component
     /// Minimum length for the grappling hook's rope
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float RopeMinLength = 0;
+    public float RopeMinLength = 0; /// Forge-Change
 
     /// <summary>
     /// Maximum length the grapple can actually be.

--- a/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
@@ -37,7 +37,7 @@ public sealed partial class GrapplingGunComponent : Component
     /// Minimum length for the grappling hook's rope
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float RopeMinLength = 1f;
+    public float RopeMinLength = 0;
 
     /// <summary>
     /// Maximum length the grapple can actually be.

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -59,6 +59,7 @@
         maxVol: 250
   - type: Spray
     transferAmount: 15
+    pushbackAmount: 150 # Forge-Change
     sprayedPrototype: BigVapor
     sprayVelocity: 3
     sprayDistance: 4.5


### PR DESCRIPTION
## О PR
### Исправил Картонные шаттлы!
_Ох да простит мою грешную душу Мерсен, я старался сделать всё по уму, но хардкодить это моя **ЖИЗНЬ!**(пожалуйста прочитай все мои изменение и дай адекватную критику чтобы я искупил свою душу, мне важно научиться делать правильно)_

Изменения касаются:
- `SpraySystem`: Теперь огнетушителями и спреями можно перемещаться с гридом если примагничен к нему!
- `SharedGrapplingSystem`: Полностью переделан, теперь крюк-пушка цепляя грид сможет его подтягивать к себе, если стоишь на другом примагниченном гриде.
- Множество мелких модификаций кода для поддержание двух систем выше.
- Мегаспрей теперь куда сильнее отталкивает чем раньше.
- Исправлено куча багов связанный с крюк-пушкой и не только.

Взял основной костяк кода из сборки визердов и адаптировал, отполировал, откалиброван и сбалансирован для Монолита. 

Были добавлены кучу проверок чтобы не допускать перетягивание грида К СЕБЕ - будучи в космосе, врубленами вакуумными ботинками, не примагниченном гриде а также модификаторы притягивание зависят от массы грида на котором стоишь и к которому притягиваешься.

Так же были исправлены баги: 
- Крюк кошка теперь даёт полёт только если крюк закреплён на гриде. Без этого владелец крюк-пушки или крюк застрявший в игроке позволял ему летать в космосе будучи закреплённом крюком к любому не статичному объекту вроде ящика или другого игрока как если бы умел летать.
- Все проджектайлы что цеплялись к поверхности чего либо становились статичными что давало право игрокам "цепляться" за них чтобы свободно летать, тем самым крюк закреплённый на игроке или стрела что в нём застряла позволяло ему свободно летать в вакууме.
- Так же был уменьшена минимальная длинна верёвки до нуля чтобы не возникало багов с коллизией верёвки и игрока что держи крюк-пушку - это коллизия позволяла проходить сквозь стены если игрок влетал в крюк-пушку с космоса на большой скорости, что реализовать очень просто учитывая насколько она сильно притягивает а так же вызывала кучу других махинаций.

Так же крюк-пушка была занёрфлена и захардкодина защита от дурака, она ограничивает работу пушки до 5 клеток чтобы игрок не мог притягиваться к крюку до конца ибо это вызывало кучу багов а также если он притягивает грид(свой и\или чужой) то расстояние между ними должно быть не меньше 150 клеток чтобы не притянуть разнеся её на всей скорости друг к другу..

Ну хотелось бы написать что это было сделано с большей долей помощи Copilot, но на деле большую часть сделал я сам а он лишь курировал и помогал найти необходимые системы, компоненты и логику.

## Зачем / Баланс

Игрок вне шаттла мало что может сделать, но найдя крюк-кошку он может притянуть себя к астероиду и уже планомерно подтягивать к себе другие объекты создавая некий кластер где сможет обустроить себе временную базу или собрать плот и на огнетушителях\подтягивая свой плот к другим объектам, отправится в открытый космос в поисках помощи.

Так же это открывает огромную кучу взаимодействий с гридами игрокам позволяя их буксировать, притягивать, отталкивать и даже брать на абордаж корабли не давая им далеко улететь зацепив их своим кораблём и крюком!

## Медиа

_Позже добавлю_

## Известные баги
Я тестировал всё больше 50 раз, но как ни старался не смог исправить следующие баги или исправил костылём:
- Если стоя на другом примагниченном гриде закрепить крюк на другой грид, то можно буксировать его своим телом вне грида, тянув(не притягивая на ПКМ а просто идти в противоположную сторону) его за собой как на поводке осла, при чем можно это делать даже без джетпака или вакуумных ботинок и даже можно залететь во внутрь грида на котором закреплён крюк и внутри тянуть его к себе чтобы толкать его на себя прям как барон Мюнхгаузен вытягивал себя за шею из болота... 
- Если убрать защиту `!IsDockedGrid(targetGrid.Value);` на 457 строчке `SharedGrapplingGunSystem.cs` то сможете тянуть к себе гриды к которым пристыкованы другие шаттлы, для других игроков это будет выглядеть нормально, но для вас пристыкованные шаттл будут наслаиваться на шаттл крюка и баговаться, от греха подальше я запретил тянуть к себе как либо гриды к которым пристыкованы другие шаттлы ибо не знаю как это исправить.
- Если выстрелить вплотную к стенке крюк-кошкой то отображение местоположение персонажа игрока сломается и его выкинет далеко от гриды до тех пор пока он не отпустит крюк-пушку или не вернёт крюк, пока это баг перестал возникать и неизвестно чем вызван, предположительно это связано с тем что минимальная длинна верёвки стала равняться нулю, но это не точно.

## Как Тестировать

1. Собираете билд,
2. Берите крюк-кошку, джетпак, вакуумные ботинки.
3. Цепляйте самые разные гриды, включая шаттлы друг к другу и смотрите что происходит и пробуйте делать:
- старайтесь включать и выключать ботинки, 
- до и после выстрела, 
- до и после притягивание, 
- до и после натягивание верёвки ,
- еще пробуйте выкидывать крюк-пушку в космос или отдавайте её другому игроку, убирайте в ящики и смотрите что будет,
- включать и выключать якорь на гриде,
- летать на гриде.
5. Записываете результат 1-3 тезисами по типу  _"Большой грид притянул к себе маленький. Маленький на большой скорости разнёс большой. Куклу игрока удалило с грида большого, после столкновения."_ и кидайте мне в дискорд.

## Требования
- [ ] Я прочитал(а) релевантные гайдлайны/документацию для этого PR на [нашем devwiki](https://monolith-station.github.io/mono-docs/).
- [X] Я добавил(а) медиа в этот PR, либо для него не требуется демонстрация в игре.
- [ ] Подтверждаю, что PR либо не содержит AI-сгенерированного контента, либо этот контент соответствует нашим правилам.

**Changelog**
:cl: Gordod3
- tweak: Гриды теперь можно перемещать огнетушителем!
- twtak: Гриды теперь можно подтягивать крюк-пушкой!