### PR TITLE
Фикс вечных тесла-болтов!

### DIFF
--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -123,7 +123,7 @@ namespace Content.Shared.Maps
         /// Effective mass of this tile for grid impacts.
         /// </summary>
         [DataField]
-        public float Mass = SharedShuttleSystem.TileDensityMultiplier; /// Forge-Change
+        public float Mass = 1000f; /// Forge-Change
 
         // <Mono>
         /// <summary>

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -483,8 +483,9 @@ public abstract partial class SharedProjectileSystem : EntitySystem
 
         _audio.PlayPredicted(component.Sound, uid, null);
         component.EmbeddedIntoUid = target;
-        // Embedded ammo should not despawn while stuck in a target.
-        RemComp<TimedDespawnComponent>(uid);
+        // Embedded ammo should not despawn while stuck in a target, exception tesla-bolts.
+        if (TryComp<ProjectileComponent>(uid, out var projectile) && projectile.FlightLifetime > 0f)
+            RemComp<TimedDespawnComponent>(uid);
         var ev = new EmbedEvent(user, target);
         RaiseLocalEvent(uid, ref ev);
         Dirty(uid, component);


### PR DESCRIPTION
## О PR
Тесла болты не исчезали после втыкание ведь в логике `EmbedAttach` не было проверки проверяющий длительность жизни при полёте а у тесла-болтов он равен нулю ибо живут фиксировано 3 секунды, но он устранялся при втыкание от чего они вечно существовали поджаривая жертву до золотистой корочки...

## Требования
<!-- Подтвердите пункты, поставив X в скобках [X]: -->
- [ ] Я прочитал(а) релевантные гайдлайны/документацию для этого PR на [нашем devwiki](https://monolith-station.github.io/mono-docs/).
- [ ] Я добавил(а) медиа в этот PR, либо для него не требуется демонстрация в игре.
- [X] Подтверждаю, что PR либо не содержит AI-сгенерированного контента, либо этот контент соответствует нашим 
**Changelog**

:cl: Gordod3
- fix: Тесла-болты снова исчезают при столкновение!