### PR TITLE
Возвращение рецепта Иридита Forge

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/lathe.yml
@@ -294,6 +294,7 @@
     - MonoCentrifugeProcessingStatic
     dynamicPacks:
     - MonoUraniumProcessing
+    - MonoIriditeProcessing # Forge-Change
   - type: MaterialStorage
     whitelist:
       tags:


### PR DESCRIPTION
## О PR
Теперь снова можно делать Иридит на миницентрифуге по рецепту Forge.

## Зачем / Баланс
Больше способов получить Иридит!

## Требования
- [X] Я прочитал(а) релевантные гайдлайны/документацию для этого PR на [нашем devwiki](https://monolith-station.github.io/mono-docs/).
- [X] Я добавил(а) медиа в этот PR, либо для него не требуется демонстрация в игре.
- [X] Подтверждаю, что PR либо не содержит AI-сгенерированного контента, либо этот контент соответствует нашим правилам.

## Как тестировать
Зайти на сервер, изучить технологию создания Иридита, проверить что в центрифуге появились рецепты.

**Changelog**
:cl:
- add: Старый рецепт Иридита вернулся
